### PR TITLE
Fix redis import

### DIFF
--- a/fsd_utils/healthchecks/checkers.py
+++ b/fsd_utils/healthchecks/checkers.py
@@ -36,9 +36,7 @@ class DbChecker(CheckerInterface):
 
 
 class RedisChecker(CheckerInterface):
-    from flask_redis import FlaskRedis
-
-    def __init__(self, redis_client: FlaskRedis):
+    def __init__(self, redis_client):  # TypeHint: FlaskRedis
         self.name = "check_redis"
         self.redis_client = redis_client
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 
 setup_kwargs = {
     "name": "funding-service-design-utils",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "Utils for the fsd-tech team",
     "long_description": None,
     "author": "DLUHC",


### PR DESCRIPTION
Removed type hint for FlaskRedis as it meant anything using this version of utils needed the redis_flask library on its path.