### PR TITLE
BAU: Filter healthcheck from access logs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 
 setup_kwargs = {
     "name": "funding-service-design-utils",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "Utils for the fsd-tech team",
     "long_description": None,
     "author": "DLUHC",


### PR DESCRIPTION
PaaS hits the healthcheck very frequently which clutters our logs.
This filters out the access logs for that route. We will still get any error/exception logs should it fail.