### PR TITLE
FS-1135 - Publish to PyPI

### DIFF
--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -93,4 +93,3 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN_TEST }}
         repository_url: https://test.pypi.org/legacy/
-        packages_dir: ${{ env.GITHUB_WORKSPACE}}/dist/

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -93,4 +93,4 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN_TEST }}
         repository_url: https://test.pypi.org/legacy/
-        packages_dir: ${{GITHUB_WORKSPACE}}/dist/
+        packages_dir: $GITHUB_WORKSPACE/dist/

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -34,11 +34,11 @@ jobs:
         python -m venv .venv
         source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-dev.txt
         pytest
+
   create-release:
     runs-on: ubuntu-latest
     needs: run-unit-tests
-    # if: github.ref == 'refs/heads/main'
-    if: 1==0
+    if: github.ref == 'refs/heads/main'
     permissions:
         contents: write
     steps:
@@ -69,8 +69,8 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
-    # needs: create-release
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fs-1135-pypi'
+    needs: create-release
+    if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3
 
@@ -91,5 +91,4 @@ jobs:
       id: publish-to-pypi
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN_TEST }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip && pip install build
         python -m build
-        echo workspace dir ${{GITHUB_WORKSPACE}}
+        echo workspace dir $GITHUB_WORKSPACE
 
     - name: Publish to PyPI
       id: publish-to-pypi

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -93,4 +93,4 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN_TEST }}
         repository_url: https://test.pypi.org/legacy/
-        packages_dir: $GITHUB_WORKSPACE/dist/
+        packages_dir: ${GITHUB_WORKSPACE}/dist/

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -37,18 +37,12 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: run-unit-tests
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
+    if: 1==0
     permissions:
         contents: write
     steps:
     - uses: actions/checkout@v3
-
-    - name: Setup python
-      id: setup_python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
     - name: Get package version
       id: package_version
       run: echo "::set-output name=app_version::"$(python setup.py --version)
@@ -72,3 +66,31 @@ jobs:
         commit: main
         tag: ${{ steps.package_version.outputs.app_version }}
         token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    runs-on: ubuntu-latest
+    # needs: create-release
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fs-1135-pypi'
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup python
+      id: setup_python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Build for publish
+      id: build_dist
+      run: |
+        python -m pip install --upgrade pip && pip install build
+        python -m build
+        echo workspace dir ${{GITHUB_WORKSPACE}}
+
+    - name: Publish to PyPI
+      id: publish-to-pypi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN_TEST }}
+        repository_url: https://test.pypi.org/legacy/
+        packages_dir: ${{GITHUB_WORKSPACE}}/dist/

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -93,4 +93,4 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN_TEST }}
         repository_url: https://test.pypi.org/legacy/
-        packages_dir: ${GITHUB_WORKSPACE}/dist/
+        packages_dir: ${{ env.GITHUB_WORKSPACE}}/dist/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,21 @@ To create a new release of funding-service-design-utils:
 1. Make and test your changes as normal in this repo
 2. Update the `version` tag in `setup.py`
 3. Push your changes to `main`.
-4. The Action at `.github/workflows/test-and-tag.yml` will create a new tag and release, named for the version in `setup.py`. This is triggered automatically on a push to main.
+4. The Action at `.github/workflows/test-and-tag.yml` will create a new tag and release, named for the version in `pyproject.toml`. This is triggered automatically on a push to main.
+5. That action will also push this tag up to PyPI at: https://pypi.org/project/funding-service-design-utils/
+
+## Updating the release workflow
+- If making changes to the release flow etc, you can publish to test.pypi.org when testing. To do this, update the `Publish to PyPI` step with the following:
+```
+    - name: Publish to PyPI
+      id: publish-to-pypi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN_TEST }}
+        repository_url: https://test.pypi.org/legacy/
+```
+- That will publish packages to https://test.pypi.org/project/funding-service-design-utils/ instead, without updating the index of the main PyPI repo.
+- Don't forget to change it back when you're done!
 
 # Usage
 Either of the following options will install the funding-service-design-utils into your python project. The package `fsd_utils` can then be imported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "funding-service-design-utils"
+version = "0.0.21.2"
+authors = [
+  { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
+]
+description = "Utilities used by the DLUHC Funding Service Design Team"
+readme = "README.md"
+license = { file="LICENSE" }
+requires-python = ">=3.10,<4.0"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/communitiesuk/funding-service-design-utils"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "0.0.21.2"
+version = "0.0.21.3"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]
@@ -16,6 +16,18 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+]
+
+dependencies = [
+    "Flask-Babel>=2.0.0,<3.0.0",
+    "PyYAML>=6.0,<7.0",
+    "python-dotenv>=0.20.0,<0.21.0",
+    "rich>=12.4.4,<13.0.0",
+    "Flask>=2.1.1,<3.0.0",
+    "python-json-logger>=2.0.2,<3.0.0",
+    "gunicorn>=20.1.0,<21.0.0",
+    "pytz>=2022.1",
+    "PyJWT[crypto]>=2.4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "0.0.21.3"
+version = "0.0.22"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "0.0.22"
+version = "0.1.0"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,22 +4,9 @@ from setuptools import setup
 
 package_data = {"": ["*"]}
 
-install_requires = [
-    "Flask-Babel>=2.0.0,<3.0.0",
-    "PyYAML>=6.0,<7.0",
-    "python-dotenv>=0.20.0,<0.21.0",
-    "rich>=12.4.4,<13.0.0",
-    "Flask>=2.1.1,<3.0.0",
-    "python-json-logger>=2.0.2,<3.0.0",
-    "gunicorn>=20.1.0,<21.0.0",
-    "pytz>=2022.1",
-    "PyJWT[crypto]>=2.4.0",
-]
-
 setup_kwargs = {
     "packages": find_packages(),
     "package_data": package_data,
-    "install_requires": install_requires,
 }
 
 setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -17,19 +17,9 @@ install_requires = [
 ]
 
 setup_kwargs = {
-    "name": "funding-service-design-utils",
-    "version": "0.0.21",
-    "description": "Utils for the fsd-tech team",
-    "long_description": None,
-    "author": "DLUHC",
-    "author_email": None,
-    "maintainer": None,
-    "maintainer_email": None,
     "packages": find_packages(),
-    "url": "https://github.com/communitiesuk/funding-service-design-utils",
     "package_data": package_data,
     "install_requires": install_requires,
-    "python_requires": ">=3.10,<4.0",
 }
 
 setup(**setup_kwargs)


### PR DESCRIPTION
Changes to the workflow to push the package up to PyPI.org when we create a tag on main.

Published to pypi-test while working on this: https://test.pypi.org/project/funding-service-design-utils/