### PR TITLE
FS-1401: sentry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,14 @@ Set `COOKIE_DOMAIN` on the app to the domain you want to set the cookie on.
 1. Once the translations are ready, use `compile` to generate the binary for use at runtime:
 
         pybabel compile -d app/translations
+
+## Sentry
+Enables Sentry integration.
+
+* Before the flask app is created initialise Sentry using
+```
+from fsd_utils import init_sentry
+
+init_sentry()
+```
+* Set the `SENTRY_DSN` environment variable on the app

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ In order to run the unit tests, setup a virtual env and install requirements
 1. Install dev requirements: `pip install --upgrade pip && pip install -r requirements-dev.txt`
 1. Install pre-commit hook: `pre-commit install`
 1. Run tests with `pytest`
-1. If you add any packages needed by services that consume `fsd_utils`, add them into `setup.py`.
+1. If you add any packages needed by services that consume `fsd_utils`, add them into `pyproject.yaml`.
 
 # Releasing
 To create a new release of funding-service-design-utils:
 1. Make and test your changes as normal in this repo
-2. Update the `version` tag in `setup.py`
+2. Update the `version` tag in `pyproject.yml`
 3. Push your changes to `main`.
 4. The Action at `.github/workflows/test-and-tag.yml` will create a new tag and release, named for the version in `pyproject.toml`. This is triggered automatically on a push to main.
 5. That action will also push this tag up to PyPI at: https://pypi.org/project/funding-service-design-utils/

--- a/fsd_utils/__init__.py
+++ b/fsd_utils/__init__.py
@@ -6,6 +6,7 @@ from fsd_utils.config.commonconfig import CommonConfig  # noqa
 from fsd_utils.config.configclass import configclass  # noqa
 from fsd_utils.config.notify_constants import NotifyConstants  # noqa
 from fsd_utils.locale_selector.set_lang import LanguageSelector
+from fsd_utils.sentry.init_sentry import init_sentry
 
 __all__ = [
     configclass,
@@ -16,4 +17,5 @@ __all__ = [
     NotifyConstants,
     healthchecks,
     LanguageSelector,
+    init_sentry,
 ]

--- a/fsd_utils/sentry/init_sentry.py
+++ b/fsd_utils/sentry/init_sentry.py
@@ -1,0 +1,16 @@
+from os import getenv
+
+import sentry_sdk
+from fsd_utils import CommonConfig
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+
+def init_sentry():
+    if getenv("SENTRY_DSN"):
+        sentry_sdk.init(
+            environment=CommonConfig.FLASK_ENV,
+            integrations=[
+                FlaskIntegration(),
+            ],
+            traces_sample_rate=0.1,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "gunicorn>=20.1.0,<21.0.0",
     "pytz>=2022.1",
     "PyJWT[crypto]>=2.4.0",
+    "sentry-sdk[flask]>=1.9.9,<2.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Adds Sentry integration, have tested locally by setting `SENTRY_DSN` on local frontend app, code is as per: https://docs.sentry.io/platforms/python/guides/flask/