### PR TITLE
Fs 1625 add csrf token time limit env var

### DIFF
--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -84,6 +84,13 @@ class CommonConfig:
     NOTIFICATION_SEND_ENDPOINT = "/send"
 
     # ---------------
+    #  SESSION TIMELIMITS
+    # ---------------
+
+    FSD_SESSION_TIMEOUT_SECONDS = 86400 #(24hrs)
+    WTF_CSRF_TIME_LIMIT = FSD_SESSION_TIMEOUT_SECONDS + 10 #(buffer secconds)
+
+    # ---------------
     #  Talisman Settings
     # ---------------
 
@@ -104,10 +111,7 @@ class CommonConfig:
         "connect-src": "",  # APPLICATION_STORE_API_HOST_PUBLIC,
         "img-src": ["data:", "'self'"],
     }
-
-    # BLAH
     
-
     # Security headers and other policies
     FSD_REFERRER_POLICY = "strict-origin-when-cross-origin"
     FSD_SESSION_COOKIE_SAMESITE = "Lax"
@@ -152,3 +156,4 @@ class CommonConfig:
     }
 
     FSD_LANG_COOKIE_NAME = "language"
+

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -105,6 +105,9 @@ class CommonConfig:
         "img-src": ["data:", "'self'"],
     }
 
+    # BLAH
+    
+
     # Security headers and other policies
     FSD_REFERRER_POLICY = "strict-origin-when-cross-origin"
     FSD_SESSION_COOKIE_SAMESITE = "Lax"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
Adding the WTF_CSRF_TIME_LIMIT and FSD_SESSION_TIMEOUT_SECONDS env-vars to be called in the frontend and authenticator services for timeout scenarios.