### PR TITLE
FS-1401: add version to sentry init (if specified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In order to run the unit tests, setup a virtual env and install requirements
 # Releasing
 To create a new release of funding-service-design-utils:
 1. Make and test your changes as normal in this repo
-2. Update the `version` tag in `pyproject.yml`
+2. Update the `version` tag in `pyproject.toml`
 3. Push your changes to `main`.
 4. The Action at `.github/workflows/test-and-tag.yml` will create a new tag and release, named for the version in `pyproject.toml`. This is triggered automatically on a push to main.
 5. That action will also push this tag up to PyPI at: https://pypi.org/project/funding-service-design-utils/

--- a/fsd_utils/sentry/init_sentry.py
+++ b/fsd_utils/sentry/init_sentry.py
@@ -13,4 +13,5 @@ def init_sentry():
                 FlaskIntegration(),
             ],
             traces_sample_rate=0.1,
+            version=getenv("GITHUB_SHA"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
This is useful to corrolate errors with releases

- add version to sentry init if specified
- bump version number
