### PR TITLE
FS-1736: disable language sniffing

### DIFF
--- a/fsd_utils/locale_selector/get_lang.py
+++ b/fsd_utils/locale_selector/get_lang.py
@@ -1,4 +1,3 @@
-from babel import negotiate_locale
 from flask import request
 from fsd_utils import CommonConfig
 
@@ -8,9 +7,14 @@ def get_lang():
     locale_from_cookie = request.cookies.get(CommonConfig.FSD_LANG_COOKIE_NAME)
     if locale_from_cookie:
         return locale_from_cookie
+    else:
+        return "en"
+
+    # TODO: Restore this when we have translated into welsh
     # otherwise guess preference based on user accept header
-    preferred = [
-        accept_language.replace("-", "_")
-        for accept_language in request.accept_languages.values()
-    ]
-    return negotiate_locale(preferred, ["en", "cy"])
+    # from babel import negotiate_locale
+    # preferred = [
+    #     accept_language.replace("-", "_")
+    #     for accept_language in request.accept_languages.values()
+    # ]
+    # return negotiate_locale(preferred, ["en", "cy"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/tests/test_get_lang.py
+++ b/tests/test_get_lang.py
@@ -15,9 +15,10 @@ class TestGetLang:
         ):
             assert get_lang() == "en"
 
-    def test_get_lang_accept_language_preference_cy(self, flask_test_client):
-        with flask_test_client.application.test_request_context(
-            "/",
-            headers={"Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"},
-        ):
-            assert get_lang() == "cy"
+    # TODO: restore this when Welsh language translation completed
+    # def test_get_lang_accept_language_preference_cy(self, flask_test_client):
+    #     with flask_test_client.application.test_request_context(
+    #         "/",
+    #         headers={"Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"}, # noqa: E501
+    #     ):
+    #         assert get_lang() == "cy"


### PR DESCRIPTION
We don't want the Welsh translations to be accessible until they are complete, so commenting out the functionality for now which sniffs locale based on the browser's settings.