### PR TITLE
FS-1855: filter healthcheck endpoint from sentry transaction monitoring

### DIFF
--- a/fsd_utils/sentry/init_sentry.py
+++ b/fsd_utils/sentry/init_sentry.py
@@ -5,6 +5,16 @@ from fsd_utils import CommonConfig
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 
+def _traces_sampler(sampling_context):
+    wsgi_environ = sampling_context.get("wsgi_environ")
+    if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
+        # Drop this transaction, by setting its sample rate to 0%
+        return 0
+    else:
+        # Default sample rate for all others (replaces traces_sample_rate)
+        return 0.1
+
+
 def init_sentry():
     if getenv("SENTRY_DSN"):
         sentry_sdk.init(
@@ -12,6 +22,6 @@ def init_sentry():
             integrations=[
                 FlaskIntegration(),
             ],
-            traces_sample_rate=0.1,
+            traces_sampler=_traces_sampler,
             release=getenv("GITHUB_SHA"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.7"
+version = "1.0.8"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
PaaS polling the `/healthcheck` endpoint used up all of our transaction allowance, we can filter out that endpoint from being included in future. This is as per Sentry documentation https://docs.sentry.io/platforms/python/configuration/filtering/#using-sampling-to-filter-transaction-events and has been tested locally.