### PR TITLE
FS-1773: Enable locale sniffing from headers

### DIFF
--- a/fsd_utils/locale_selector/get_lang.py
+++ b/fsd_utils/locale_selector/get_lang.py
@@ -1,3 +1,4 @@
+from babel import negotiate_locale
 from flask import request
 from fsd_utils import CommonConfig
 
@@ -7,14 +8,15 @@ def get_lang():
     locale_from_cookie = request.cookies.get(CommonConfig.FSD_LANG_COOKIE_NAME)
     if locale_from_cookie:
         return locale_from_cookie
-    else:
-        return "en"
 
-    # TODO: Restore this when we have translated into welsh
     # otherwise guess preference based on user accept header
-    # from babel import negotiate_locale
-    # preferred = [
-    #     accept_language.replace("-", "_")
-    #     for accept_language in request.accept_languages.values()
-    # ]
-    # return negotiate_locale(preferred, ["en", "cy"])
+    preferred = [
+        accept_language.replace("-", "_")
+        for accept_language in request.accept_languages.values()
+    ]
+    negotiated_locale = negotiate_locale(preferred, ["en", "cy"])
+    if negotiated_locale:
+        return negotiated_locale
+
+    # default is to return english
+    return "en"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.12"
+version = "1.0.13"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/tests/test_get_lang.py
+++ b/tests/test_get_lang.py
@@ -15,10 +15,11 @@ class TestGetLang:
         ):
             assert get_lang() == "en"
 
-    # TODO: restore this when Welsh language translation completed
-    # def test_get_lang_accept_language_preference_cy(self, flask_test_client):
-    #     with flask_test_client.application.test_request_context(
-    #         "/",
-    #         headers={"Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"}, # noqa: E501
-    #     ):
-    #         assert get_lang() == "cy"
+    def test_get_lang_accept_language_preference_cy(self, flask_test_client):
+        with flask_test_client.application.test_request_context(
+            "/",
+            headers={
+                "Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"
+            },  # noqa: E501
+        ):
+            assert get_lang() == "cy"


### PR DESCRIPTION
Re-enabled locale sniffing.  Will infer language from headers if cookie isn't set.

Tested locally:  (and there are code tests that existed)
https://user-images.githubusercontent.com/117724519/206164120-54642934-40ef-43d8-b591-ed3ff38938df.mp4

