### PR TITLE
FS-1773: Pull language from accept header regardless of casing

### DIFF
--- a/fsd_utils/locale_selector/get_lang.py
+++ b/fsd_utils/locale_selector/get_lang.py
@@ -1,6 +1,7 @@
-from babel import negotiate_locale
+from babel.core import negotiate_locale
 from flask import request
 from fsd_utils import CommonConfig
+from werkzeug.http import parse_accept_header
 
 
 def get_lang():
@@ -9,14 +10,27 @@ def get_lang():
     if locale_from_cookie:
         return locale_from_cookie
 
-    # otherwise guess preference based on user accept header
-    preferred = [
-        accept_language.replace("-", "_")
-        for accept_language in request.accept_languages.values()
-    ]
-    negotiated_locale = negotiate_locale(preferred, ["en", "cy"])
-    if negotiated_locale:
-        return negotiated_locale
+    # if no cookie, get locale from accept header
+    # if found guess preference based on user accept header
+    accept_language_key = next(
+        (
+            key
+            for key in request.headers.keys()
+            if key.lower() == "accept-language"
+        ),
+        None,
+    )
+    if accept_language_key:
+        preferred = [
+            accept_language.replace("-", "_")
+            for accept_language in parse_accept_header(
+                request.headers.get(accept_language_key)
+            ).values()
+        ]
+
+        negotiated_locale = negotiate_locale(preferred, ["en", "cy"])
+        if negotiated_locale:
+            return negotiated_locale
 
     # default is to return english
     return "en"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.13"
+version = "1.0.14"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/tests/test_get_lang.py
+++ b/tests/test_get_lang.py
@@ -1,3 +1,4 @@
+import pytest
 from fsd_utils.locale_selector.get_lang import get_lang
 
 
@@ -21,5 +22,28 @@ class TestGetLang:
             headers={
                 "Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"
             },  # noqa: E501
+        ):
+            assert get_lang() == "cy"
+
+    @pytest.mark.parametrize(
+        "accept_language_header_key",
+        [
+            "Accept-Language",
+            "accept-language",
+            "ACCEPT-LANGUAGE",
+            "Accept-language",
+            "accept-Language",
+            "ACCEPT-language",
+            "Accept-LANGUAGE",
+        ],
+    )
+    def test_get_lang_accept_language_preference_regardless_of_header_key_case(
+        self, flask_test_client, accept_language_header_key
+    ):
+        with flask_test_client.application.test_request_context(
+            "/",
+            headers={
+                accept_language_header_key: "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"  # noqa: E501
+            },
         ):
             assert get_lang() == "cy"


### PR DESCRIPTION
In scenarios where the users `Accept-Language` header is in a different casing, locale sniffing won't work.

This PR should address that by searching for a header that matches regardless of casing.