### PR TITLE
BAU: add debug user role bypass to auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.16"
+version = "1.0.17"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
### Add development auth bypass functionality to login_required decorator

- When FLASK_ENV == "development" and DEBUG_USER and DEBUG_USER_ROLE config vars are set, then use these values to set the request user and roles (instead of the fsd_user_token cookie) - this is to allow easy checking of functionality during local development on routes decorated with the @login_required decorator