### PR TITLE
BAU: don't log healthcheck and only log after_request at info level

### DIFF
--- a/fsd_utils/logging/logging.py
+++ b/fsd_utils/logging/logging.py
@@ -74,26 +74,31 @@ def init_app(app):
 
     @app.after_request
     def after_request(response):
-        current_app.logger.log(
-            logging.ERROR
-            if response.status_code // 100 == 5
-            else logging.INFO,
-            "{method} {url} {status}",
-            extra={
-                "status": response.status_code,
-                "duration_real": (
-                    (time.perf_counter() - request.before_request_real_time)
-                    if hasattr(request, "before_request_real_time")
-                    else None
-                ),
-                "duration_process": (
-                    (time.process_time() - request.before_request_process_time)
-                    if hasattr(request, "before_request_process_time")
-                    else None
-                ),
-                **_common_request_extra_log_context(),
-            },
-        )
+        if request.path != "/healthcheck":
+            current_app.logger.log(
+                logging.INFO,
+                "{method} {url} {status}",
+                extra={
+                    "status": response.status_code,
+                    "duration_real": (
+                        (
+                            time.perf_counter()
+                            - request.before_request_real_time
+                        )
+                        if hasattr(request, "before_request_real_time")
+                        else None
+                    ),
+                    "duration_process": (
+                        (
+                            time.process_time()
+                            - request.before_request_process_time
+                        )
+                        if hasattr(request, "before_request_process_time")
+                        else None
+                    ),
+                    **_common_request_extra_log_context(),
+                },
+            )
         return response
 
     logging.getLogger().addHandler(logging.NullHandler())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.17"
+version = "1.0.18"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
Remove extraneous logging of healthcheck, and erroneous error logging in `after_request` method.

This should remove the erroneous errors as seen below, as this will only log at `info` level now.
<img width="689" alt="Screenshot 2023-01-10 at 14 13 39" src="https://user-images.githubusercontent.com/1764158/211574150-db15056d-81ef-43a2-8aad-21905632a0b9.png">
