### PR TITLE
FS-2159: set user in sentry

### DIFF
--- a/fsd_utils/__init__.py
+++ b/fsd_utils/__init__.py
@@ -6,7 +6,9 @@ from fsd_utils.config.commonconfig import CommonConfig  # noqa
 from fsd_utils.config.configclass import configclass  # noqa
 from fsd_utils.config.notify_constants import NotifyConstants  # noqa
 from fsd_utils.locale_selector.set_lang import LanguageSelector
+from fsd_utils.sentry.init_sentry import clear_sentry
 from fsd_utils.sentry.init_sentry import init_sentry
+
 
 __all__ = [
     configclass,
@@ -18,4 +20,5 @@ __all__ = [
     healthchecks,
     LanguageSelector,
     init_sentry,
+    clear_sentry,
 ]

--- a/fsd_utils/authentication/models.py
+++ b/fsd_utils/authentication/models.py
@@ -2,7 +2,10 @@
 Data models for authentication
 """
 from dataclasses import dataclass
+from os import getenv
 from typing import List
+
+from sentry_sdk import set_user
 
 from .utils import get_highest_role
 
@@ -19,6 +22,15 @@ class User:
         full_name = token_payload.get("fullName")
         email = token_payload.get("email")
         roles = token_payload.get("roles")
+        # Set user in Sentry
+        if getenv("SENTRY_DSN"):
+            set_user(
+                {
+                    "email": token_payload.get("email"),
+                    "id": token_payload.get("accountId"),
+                    "username": token_payload.get("fullName"),
+                }
+            )
         return cls(
             full_name=full_name,
             email=email,

--- a/fsd_utils/sentry/init_sentry.py
+++ b/fsd_utils/sentry/init_sentry.py
@@ -25,3 +25,8 @@ def init_sentry():
             traces_sampler=_traces_sampler,
             release=getenv("GITHUB_SHA"),
         )
+
+
+def clear_sentry():
+    if getenv("SENTRY_DSN"):
+        sentry_sdk.set_user(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.18"
+version = "1.0.19"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
see https://docs.sentry.io/platforms/python/guides/flask/enriching-events/identify-user/ for context

I have tested this using a branch of utils on assessment and I can see the user context coming through e.g. 
<img width="1090" alt="Screenshot 2023-01-13 at 10 33 17" src="https://user-images.githubusercontent.com/1764158/212332583-ab6b3432-6637-4f07-92f0-a6a323b6fa3b.png">
