### PR TITLE
Fs 2181 default ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ class DefaultConfig:
 
 ```
 
-This also defines a function `get_default_round_id` to determine the current default round ID based on the current date and the opening date of COF_R2_W3. The default launch date is `2023-02-08 12:00:00` but this can be overridden in the environment by setting the following env var:
-
-        export COF_R2_W3_LAUNCH_TIME=2023-01-01
+This also defines a function `get_default_round_id` to determine the current default round ID based on the current date and the opening date of COF_R2_W3. The opening dates are determined by the fund store.
 
 ## Gunicorn
 The gunicorn utility allows consistent configuration of gunicorn across microservices.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ class DefaultConfig:
 
 ```
 
+This also defines a function `get_default_round_id` to determine the current default round ID based on the current date and the opening date of COF_R2_W3. The default launch date is `2023-02-08 12:00:00` but this can be overridden in the environment by setting the following env var:
+
+        export COF_R2_W3_LAUNCH_TIME=2023-01-01
+
 ## Gunicorn
 The gunicorn utility allows consistent configuration of gunicorn across microservices.
 
@@ -233,3 +237,9 @@ from fsd_utils import init_sentry
 init_sentry()
 ```
 * Set the `SENTRY_DSN` environment variable on the app
+
+## Simple Utils
+Folder to hold miscellaneous simple utilities.
+
+### date_utils
+Date comparison functions that accept an ISO Format string, for use in the frontend determining display logic based on dates.

--- a/fsd_utils/__init__.py
+++ b/fsd_utils/__init__.py
@@ -8,6 +8,7 @@ from fsd_utils.config.notify_constants import NotifyConstants  # noqa
 from fsd_utils.locale_selector.set_lang import LanguageSelector
 from fsd_utils.sentry.init_sentry import clear_sentry
 from fsd_utils.sentry.init_sentry import init_sentry
+from fsd_utils.simple_utils import date_utils  # noqa
 
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     LanguageSelector,
     init_sentry,
     clear_sentry,
+    date_utils,
 ]

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -176,27 +176,28 @@ class CommonConfig:
     DEFAULT_FUND_ID = COF_FUND_ID
     COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
 
-    def get_default_round_id():
-        CommonConfig.COF_R2_W3_LAUNCH_TIME = os.getenv(
-            "COF_R2_W3_LAUNCH_TIME", CommonConfig.COF_R2_W3_DEFAULT_LAUNCH_TIME
+    @classmethod
+    def get_default_round_id(cls):
+        cls.COF_R2_W3_LAUNCH_TIME = os.getenv(
+            "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
         )
         try:
-            CommonConfig.COF_R2_W3_IS_OPEN: bool = (
+            cls.COF_R2_W3_IS_OPEN: bool = (
                 current_datetime_after_given_iso_string(
-                    CommonConfig.COF_R2_W3_LAUNCH_TIME
+                    cls.COF_R2_W3_LAUNCH_TIME
                 )
             )
         except:  # noqa:E722
-            CommonConfig.COF_R2_W3_IS_OPEN: bool = (
+            cls.COF_R2_W3_IS_OPEN: bool = (
                 current_datetime_after_given_iso_string(
-                    CommonConfig.COF_R2_W3_DEFAULT_LAUNCH_TIME
+                    cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
                 )
             )
 
-        if CommonConfig.COF_R2_W3_IS_OPEN:
-            return CommonConfig.COF_ROUND_2_W3_ID
+        if cls.COF_R2_W3_IS_OPEN:
+            return cls.COF_ROUND_2_W3_ID
         else:
-            return CommonConfig.COF_ROUND_2_ID
+            return cls.COF_ROUND_2_ID
 
     # ---------------
     #  Form Config

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -291,19 +291,22 @@ class CommonConfig:
 
     @classmethod
     def get_default_round_id(cls):
-        r2_w3 = get_remote_data_as_json(
-            cls.FUND_STORE_API_HOST
-            + cls.ROUND_ENDPOINT.format(
-                fund_id=cls.COF_FUND_ID, round_id=cls.COF_ROUND_2_W3_ID
+        try:
+            r2_w3 = get_remote_data_as_json(
+                cls.FUND_STORE_API_HOST
+                + cls.ROUND_ENDPOINT.format(
+                    fund_id=cls.COF_FUND_ID, round_id=cls.COF_ROUND_2_W3_ID
+                )
             )
-        )
-        cof_r2_w3_is_open = current_datetime_after_given_iso_string(
-            r2_w3["opens"]
-        )
+            cof_r2_w3_is_open = current_datetime_after_given_iso_string(
+                r2_w3["opens"]
+            )
 
-        if cof_r2_w3_is_open:
-            return cls.COF_ROUND_2_W3_ID
-        else:
+            if cof_r2_w3_is_open:
+                return cls.COF_ROUND_2_W3_ID
+            else:
+                return cls.COF_ROUND_2_ID
+        except Exception as e:  # noqa:F841
             return cls.COF_ROUND_2_ID
 
     FORMS_CONFIG_FOR_FUND_ROUND = {

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from flask import current_app
 from fsd_utils.simple_utils.data_utils import get_remote_data_as_json
 from fsd_utils.simple_utils.date_utils import (
     current_datetime_after_given_iso_string,
@@ -303,7 +302,7 @@ class CommonConfig:
             r2_w3["opens"]
         )
 
-        current_app.logger.info(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
+        print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
 
         if cof_r2_w3_is_open:
             return cls.COF_ROUND_2_W3_ID

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from flask import current_app
+from fsd_utils.simple_utils.data_utils import get_remote_data_as_json
 from fsd_utils.simple_utils.date_utils import (
     current_datetime_after_given_iso_string,
 )
@@ -286,31 +288,47 @@ class CommonConfig:
     COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
     COF_ROUND_2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
     COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
-    COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
+    # COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
     DEFAULT_FUND_ID = COF_FUND_ID
 
     @classmethod
     def get_default_round_id(cls):
-        launch_time = os.getenv(
-            "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
+        r2_w3 = get_remote_data_as_json(
+            cls.ROUND_ENDPOINT.format(
+                fund_id=cls.COF_FUND_ID, round_id=cls.COF_ROUND_2_W3_ID
+            )
         )
-        print(f"COF R2W3 launch time from env: {str(launch_time)}")
-        try:
-            cof_r2_w3_is_open = current_datetime_after_given_iso_string(
-                launch_time
-            )
-        except:  # noqa:E722
-            print("exception parsing launch date")
-            cof_r2_w3_is_open = current_datetime_after_given_iso_string(
-                cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
-            )
+        cof_r2_w3_is_open = current_datetime_after_given_iso_string(
+            r2_w3["opens"]
+        )
 
-        print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
+        current_app.logger.info(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
 
         if cof_r2_w3_is_open:
             return cls.COF_ROUND_2_W3_ID
         else:
             return cls.COF_ROUND_2_ID
+
+        # launch_time = os.getenv(
+        #     "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
+        # )
+        # print(f"COF R2W3 launch time from env: {str(launch_time)}")
+        # try:
+        #     cof_r2_w3_is_open = current_datetime_after_given_iso_string(
+        #         launch_time
+        #     )
+        # except:  # noqa:E722
+        #     print("exception parsing launch date")
+        #     cof_r2_w3_is_open = current_datetime_after_given_iso_string(
+        #         cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
+        #     )
+
+        # print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
+
+        # if cof_r2_w3_is_open:
+        #     return cls.COF_ROUND_2_W3_ID
+        # else:
+        #     return cls.COF_ROUND_2_ID
 
     FORMS_CONFIG_FOR_FUND_ROUND = {
         f"{COF_FUND_ID}:{COF_ROUND_2_ID}": COF_R2_ORDERED_FORMS_CONFIG,

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -181,7 +181,9 @@ class CommonConfig:
         cls.COF_R2_W3_LAUNCH_TIME = os.getenv(
             "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
         )
-        print("COF R2W3 launch time from env: " + cls.COF_R2_W3_LAUNCH_TIME)
+        print(
+            f"COF R2W3 launch time from env: {str(cls.COF_R2_W3_LAUNCH_TIME)}"
+        )
         try:
             cls.COF_R2_W3_IS_OPEN: bool = (
                 current_datetime_after_given_iso_string(
@@ -196,7 +198,7 @@ class CommonConfig:
                 )
             )
 
-        print("COF_R2_W3 is open: " + cls.COF_R2_W3_IS_OPEN)
+        print(f"COF_R2_W3 is open: {str(cls.COF_R2_W3_IS_OPEN)}")
 
         if cls.COF_R2_W3_IS_OPEN:
             return cls.COF_ROUND_2_W3_ID

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -301,8 +301,6 @@ class CommonConfig:
             r2_w3["opens"]
         )
 
-        print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
-
         if cof_r2_w3_is_open:
             return cls.COF_ROUND_2_W3_ID
         else:

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -291,23 +291,23 @@ class CommonConfig:
 
     @classmethod
     def get_default_round_id(cls):
-        COF_R2_W3_LAUNCH_TIME = os.getenv(
+        launch_time = os.getenv(
             "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
         )
-        print(f"COF R2W3 launch time from env: {str(COF_R2_W3_LAUNCH_TIME)}")
+        print(f"COF R2W3 launch time from env: {str(launch_time)}")
         try:
-            COF_R2_W3_IS_OPEN: bool = current_datetime_after_given_iso_string(
-                COF_R2_W3_LAUNCH_TIME
+            cof_r2_w3_is_open = current_datetime_after_given_iso_string(
+                launch_time
             )
         except:  # noqa:E722
             print("exception parsing launch date")
-            COF_R2_W3_IS_OPEN: bool = current_datetime_after_given_iso_string(
+            cof_r2_w3_is_open = current_datetime_after_given_iso_string(
                 cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
             )
 
-        print(f"COF_R2_W3 is open: {str(COF_R2_W3_IS_OPEN)}")
+        print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
 
-        if COF_R2_W3_IS_OPEN:
+        if cof_r2_w3_is_open:
             return cls.COF_ROUND_2_W3_ID
         else:
             return cls.COF_ROUND_2_ID

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -166,46 +166,6 @@ class CommonConfig:
     FSD_LANG_COOKIE_NAME = "language"
 
     # ---------------
-    #  Fund Config
-    # ---------------
-
-    COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
-    COF_ROUND_2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
-    COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
-
-    DEFAULT_FUND_ID = COF_FUND_ID
-    COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
-
-    @classmethod
-    def get_default_round_id(cls):
-        cls.COF_R2_W3_LAUNCH_TIME = os.getenv(
-            "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
-        )
-        print(
-            f"COF R2W3 launch time from env: {str(cls.COF_R2_W3_LAUNCH_TIME)}"
-        )
-        try:
-            cls.COF_R2_W3_IS_OPEN: bool = (
-                current_datetime_after_given_iso_string(
-                    cls.COF_R2_W3_LAUNCH_TIME
-                )
-            )
-        except:  # noqa:E722
-            print("exception parsing launch date")
-            cls.COF_R2_W3_IS_OPEN: bool = (
-                current_datetime_after_given_iso_string(
-                    cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
-                )
-            )
-
-        print(f"COF_R2_W3 is open: {str(cls.COF_R2_W3_IS_OPEN)}")
-
-        if cls.COF_R2_W3_IS_OPEN:
-            return cls.COF_ROUND_2_W3_ID
-        else:
-            return cls.COF_ROUND_2_ID
-
-    # ---------------
     #  Form Config
     # ---------------
 
@@ -318,6 +278,40 @@ class CommonConfig:
             "section_weighting": None,
         },
     )
+
+    # ---------------
+    #  Fund Config
+    # ---------------
+
+    COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
+    COF_ROUND_2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
+    COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
+    COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
+    DEFAULT_FUND_ID = COF_FUND_ID
+
+    @classmethod
+    def get_default_round_id(cls):
+        COF_R2_W3_LAUNCH_TIME = os.getenv(
+            "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
+        )
+        print(f"COF R2W3 launch time from env: {str(COF_R2_W3_LAUNCH_TIME)}")
+        try:
+            COF_R2_W3_IS_OPEN: bool = current_datetime_after_given_iso_string(
+                COF_R2_W3_LAUNCH_TIME
+            )
+        except:  # noqa:E722
+            print("exception parsing launch date")
+            COF_R2_W3_IS_OPEN: bool = current_datetime_after_given_iso_string(
+                cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
+            )
+
+        print(f"COF_R2_W3 is open: {str(COF_R2_W3_IS_OPEN)}")
+
+        if COF_R2_W3_IS_OPEN:
+            return cls.COF_ROUND_2_W3_ID
+        else:
+            return cls.COF_ROUND_2_ID
+
     FORMS_CONFIG_FOR_FUND_ROUND = {
         f"{COF_FUND_ID}:{COF_ROUND_2_ID}": COF_R2_ORDERED_FORMS_CONFIG,
         f"{COF_FUND_ID}:{COF_ROUND_2_W3_ID}": COF_R2_ORDERED_FORMS_CONFIG,

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -287,7 +287,6 @@ class CommonConfig:
     COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
     COF_ROUND_2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
     COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
-    # COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
     DEFAULT_FUND_ID = COF_FUND_ID
 
     @classmethod
@@ -308,27 +307,6 @@ class CommonConfig:
             return cls.COF_ROUND_2_W3_ID
         else:
             return cls.COF_ROUND_2_ID
-
-        # launch_time = os.getenv(
-        #     "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
-        # )
-        # print(f"COF R2W3 launch time from env: {str(launch_time)}")
-        # try:
-        #     cof_r2_w3_is_open = current_datetime_after_given_iso_string(
-        #         launch_time
-        #     )
-        # except:  # noqa:E722
-        #     print("exception parsing launch date")
-        #     cof_r2_w3_is_open = current_datetime_after_given_iso_string(
-        #         cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
-        #     )
-
-        # print(f"COF_R2_W3 is open: {str(cof_r2_w3_is_open)}")
-
-        # if cof_r2_w3_is_open:
-        #     return cls.COF_ROUND_2_W3_ID
-        # else:
-        #     return cls.COF_ROUND_2_ID
 
     FORMS_CONFIG_FOR_FUND_ROUND = {
         f"{COF_FUND_ID}:{COF_ROUND_2_ID}": COF_R2_ORDERED_FORMS_CONFIG,

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -294,7 +294,8 @@ class CommonConfig:
     @classmethod
     def get_default_round_id(cls):
         r2_w3 = get_remote_data_as_json(
-            cls.ROUND_ENDPOINT.format(
+            cls.FUND_STORE_API_HOST
+            + cls.ROUND_ENDPOINT.format(
                 fund_id=cls.COF_FUND_ID, round_id=cls.COF_ROUND_2_W3_ID
             )
         )

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -181,6 +181,7 @@ class CommonConfig:
         cls.COF_R2_W3_LAUNCH_TIME = os.getenv(
             "COF_R2_W3_LAUNCH_TIME", cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
         )
+        print("COF R2W3 launch time from env: " + cls.COF_R2_W3_LAUNCH_TIME)
         try:
             cls.COF_R2_W3_IS_OPEN: bool = (
                 current_datetime_after_given_iso_string(
@@ -188,11 +189,14 @@ class CommonConfig:
                 )
             )
         except:  # noqa:E722
+            print("exception parsing launch date")
             cls.COF_R2_W3_IS_OPEN: bool = (
                 current_datetime_after_given_iso_string(
                     cls.COF_R2_W3_DEFAULT_LAUNCH_TIME
                 )
             )
+
+        print("COF_R2_W3 is open: " + cls.COF_R2_W3_IS_OPEN)
 
         if cls.COF_R2_W3_IS_OPEN:
             return cls.COF_ROUND_2_W3_ID

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -1,6 +1,10 @@
 import logging
 import os
 
+from fsd_utils.simple_utils.date_utils import (
+    current_datetime_after_given_iso_string,
+)
+
 
 class CommonConfig:
 
@@ -168,6 +172,31 @@ class CommonConfig:
     COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
     COF_ROUND_2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
     COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
+
+    DEFAULT_FUND_ID = COF_FUND_ID
+    COF_R2_W3_DEFAULT_LAUNCH_TIME = "2023-02-08 12:00:00"
+
+    def get_default_round_id():
+        CommonConfig.COF_R2_W3_LAUNCH_TIME = os.getenv(
+            "COF_R2_W3_LAUNCH_TIME", CommonConfig.COF_R2_W3_DEFAULT_LAUNCH_TIME
+        )
+        try:
+            CommonConfig.COF_R2_W3_IS_OPEN: bool = (
+                current_datetime_after_given_iso_string(
+                    CommonConfig.COF_R2_W3_LAUNCH_TIME
+                )
+            )
+        except:  # noqa:E722
+            CommonConfig.COF_R2_W3_IS_OPEN: bool = (
+                current_datetime_after_given_iso_string(
+                    CommonConfig.COF_R2_W3_DEFAULT_LAUNCH_TIME
+                )
+            )
+
+        if CommonConfig.COF_R2_W3_IS_OPEN:
+            return CommonConfig.COF_ROUND_2_W3_ID
+        else:
+            return CommonConfig.COF_ROUND_2_ID
 
     # ---------------
     #  Form Config

--- a/fsd_utils/simple_utils/data_utils.py
+++ b/fsd_utils/simple_utils/data_utils.py
@@ -1,0 +1,16 @@
+import requests
+from flask import current_app
+
+
+def get_remote_data_as_json(endpoint):
+
+    response = requests.get(endpoint)
+    if response.status_code == 200:
+        data = response.json()
+        return data
+    else:
+        current_app.logger.warn(
+            "GET remote data call was unsuccessful with status code:"
+            f" {response.status_code} body: {response.content}."
+        )
+        return None

--- a/fsd_utils/simple_utils/data_utils.py
+++ b/fsd_utils/simple_utils/data_utils.py
@@ -11,6 +11,6 @@ def get_remote_data_as_json(endpoint):
     else:
         current_app.logger.warn(
             "GET remote data call was unsuccessful with status code:"
-            f" {response.status_code} body: {response.content}."
+            f" {response.status_code} body: {response.text}."
         )
-        return None
+        response.raise_for_status()

--- a/fsd_utils/simple_utils/date_utils.py
+++ b/fsd_utils/simple_utils/date_utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+
+def current_datetime_after_given_iso_string(value: str) -> bool:
+    today = datetime.today().now()
+    parsed = datetime.fromisoformat(value)
+    return today > parsed
+
+
+def current_datetime_before_given_iso_string(value: str) -> bool:
+    today = datetime.today().now()
+    parsed = datetime.fromisoformat(value)
+    return today < parsed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.21"
+version = "1.0.22"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "gunicorn>=20.1.0,<21.0.0",
     "pytz>=2022.1",
     "PyJWT[crypto]>=2.4.0",
-    "sentry-sdk[flask]>=1.9.9,<2.0.0"
+    "sentry-sdk[flask]>=1.9.9,<2.0.0",
+    "requests"
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-env>=0.6.2
 sqlalchemy==1.4.39
 flask-redis==0.4.0
 pytest
+pytest-mock

--- a/tests/test_cof_dates.py
+++ b/tests/test_cof_dates.py
@@ -1,14 +1,10 @@
-from datetime import datetime
-from datetime import timedelta
-
 from fsd_utils.config.commonconfig import CommonConfig
 
 
-def test_get_default_round_id_before_w3(mocker):
+def test_get_default_round_id_before_w3(mocker, flask_test_client):
     mocker.patch(
-        "fsd_utils.config.commonconfig."
-        + "current_datetime_after_given_iso_string",
-        return_value=False,
+        "fsd_utils.config.commonconfig.get_remote_data_as_json",
+        return_value={"opens": "2029-01-01"},
     )
     default_round_id = CommonConfig.get_default_round_id()
     assert (
@@ -16,32 +12,11 @@ def test_get_default_round_id_before_w3(mocker):
     ), "Should be before W3 launch date"
 
 
-def test_get_default_round_id_after_w3(mocker):
+def test_get_default_round_id_after_w3(mocker, flask_test_client):
     mocker.patch(
-        "fsd_utils.config.commonconfig."
-        + "current_datetime_after_given_iso_string",
-        return_value=True,
+        "fsd_utils.config.commonconfig.get_remote_data_as_json",
+        return_value={"opens": "2023-01-01"},
     )
-    default_round_id = CommonConfig.get_default_round_id()
-    assert (
-        CommonConfig.COF_ROUND_2_W3_ID == default_round_id
-    ), "Should be after W3 launch date"
-
-
-def test_get_default_round_id_before_after_w3(monkeypatch):
-    today = datetime.today().now()
-    earlier = today - timedelta(hours=1)
-    later = today + timedelta(hours=1)
-
-    monkeypatch.setenv("COF_R2_W3_LAUNCH_TIME", str(later))
-
-    default_round_id = CommonConfig.get_default_round_id()
-    assert (
-        CommonConfig.COF_ROUND_2_ID == default_round_id
-    ), "Should be before W3 launch date"
-
-    monkeypatch.setenv("COF_R2_W3_LAUNCH_TIME", str(earlier))
-
     default_round_id = CommonConfig.get_default_round_id()
     assert (
         CommonConfig.COF_ROUND_2_W3_ID == default_round_id

--- a/tests/test_cof_dates.py
+++ b/tests/test_cof_dates.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from datetime import timedelta
+
+from fsd_utils.config.commonconfig import CommonConfig
+
+
+def test_get_default_round_id_before_w3(mocker):
+    mocker.patch(
+        "fsd_utils.config.commonconfig."
+        + "current_datetime_after_given_iso_string",
+        return_value=False,
+    )
+    default_round_id = CommonConfig.get_default_round_id()
+    assert (
+        CommonConfig.COF_ROUND_2_ID == default_round_id
+    ), "Should be before W3 launch date"
+
+
+def test_get_default_round_id_after_w3(mocker):
+    mocker.patch(
+        "fsd_utils.config.commonconfig."
+        + "current_datetime_after_given_iso_string",
+        return_value=True,
+    )
+    default_round_id = CommonConfig.get_default_round_id()
+    assert (
+        CommonConfig.COF_ROUND_2_W3_ID == default_round_id
+    ), "Should be after W3 launch date"
+
+
+def test_get_default_round_id_before_after_w3(monkeypatch):
+    today = datetime.today().now()
+    earlier = today - timedelta(hours=1)
+    later = today + timedelta(hours=1)
+
+    monkeypatch.setenv("COF_R2_W3_LAUNCH_TIME", str(later))
+
+    default_round_id = CommonConfig.get_default_round_id()
+    assert (
+        CommonConfig.COF_ROUND_2_ID == default_round_id
+    ), "Should be before W3 launch date"
+
+    monkeypatch.setenv("COF_R2_W3_LAUNCH_TIME", str(earlier))
+
+    default_round_id = CommonConfig.get_default_round_id()
+    assert (
+        CommonConfig.COF_ROUND_2_W3_ID == default_round_id
+    ), "Should be after W3 launch date"

--- a/tests/test_cof_dates.py
+++ b/tests/test_cof_dates.py
@@ -1,7 +1,7 @@
 from fsd_utils.config.commonconfig import CommonConfig
 
 
-def test_get_default_round_id_before_w3(mocker, flask_test_client):
+def test_get_default_round_id_before_w3(mocker):
     mocker.patch(
         "fsd_utils.config.commonconfig.get_remote_data_as_json",
         return_value={"opens": "2029-01-01"},
@@ -12,7 +12,7 @@ def test_get_default_round_id_before_w3(mocker, flask_test_client):
     ), "Should be before W3 launch date"
 
 
-def test_get_default_round_id_after_w3(mocker, flask_test_client):
+def test_get_default_round_id_after_w3(mocker):
     mocker.patch(
         "fsd_utils.config.commonconfig.get_remote_data_as_json",
         return_value={"opens": "2023-01-01"},

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,16 @@
+import pytest
+from fsd_utils.simple_utils.data_utils import get_remote_data_as_json
+from requests.exceptions import HTTPError
+
+
+class TestDataUtils:
+    def test_get_remote_data_json(self, flask_test_client):
+        postcode = "SW1P 4DF"
+        result = get_remote_data_as_json(
+            f"https://postcodes.io/postcodes/{postcode}"
+        )
+        assert postcode == result["result"]["postcode"]
+
+    def test_get_remote_data_json_404(self, flask_test_client):
+        with pytest.raises(HTTPError):
+            get_remote_data_as_json("https://postcodes.io/postcodes/QQ11QQ")


### PR DESCRIPTION
Adding logic to determine default round ID based on env vars. Allos the cof r2w3 launch date to be overridden by an env var and then determines the default round ID based on whether or not that round is open yet.