### PR TITLE
fs-2277-toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When working and testing locally, you can also install the `fsd_utils` package f
     pip uninstall -y funding-service-design-utils
     pip install /path/to/your/working/directory/funding-service-design/utils
 
-Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils. to avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up` or just running `docker compose up --build` on its own.
+Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils. to avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up` or just running `docker compose up <service_name>` on its own.
 
 # Utilities
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ When working and testing locally, you can also install the `fsd_utils` package f
     pip uninstall -y funding-service-design-utils
     pip install /path/to/your/working/directory/funding-service-design/utils
 
+Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils. to avoid this and pick up your intended changes, run `docker compose build` first before running `docker compose up` or just running `docker compose up --build` on its own.
+
 # Utilities
 
 ## The configclass

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When working and testing locally, you can also install the `fsd_utils` package f
     pip uninstall -y funding-service-design-utils
     pip install /path/to/your/working/directory/funding-service-design/utils
 
-Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils. to avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up` or just running `docker compose up <service_name>` on its own.
+Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils. to avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up`.
 
 # Utilities
 

--- a/fsd_utils/__init__.py
+++ b/fsd_utils/__init__.py
@@ -2,6 +2,7 @@ from fsd_utils import authentication  # noqa
 from fsd_utils import gunicorn  # noqa
 from fsd_utils import healthchecks
 from fsd_utils import logging  # noqa
+from fsd_utils import toggles
 from fsd_utils.config.commonconfig import CommonConfig  # noqa
 from fsd_utils.config.configclass import configclass  # noqa
 from fsd_utils.config.notify_constants import NotifyConstants  # noqa
@@ -23,4 +24,5 @@ __all__ = [
     init_sentry,
     clear_sentry,
     date_utils,
+    toggles,
 ]

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -289,6 +289,22 @@ class CommonConfig:
     COF_ROUND_2_W3_ID = "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f"
     DEFAULT_FUND_ID = COF_FUND_ID
 
+    # ---------------
+    #  Feature Toggles
+    # ---------------
+
+    dev_feature_configuration = {
+        "FLAGGING": True,
+        "COMMENTING": True,
+        "REMINDERS": False
+    }
+
+    prod_feature_configuration = {
+        "FLAGGING": False,
+        "COMMENTING": True,
+        "REMINDERS": False
+    }
+
     @classmethod
     def get_default_round_id(cls):
         try:

--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -294,15 +294,16 @@ class CommonConfig:
     # ---------------
 
     dev_feature_configuration = {
-        "FLAGGING": True,
-        "COMMENTING": True,
-        "REMINDERS": False
+        # TODO: add features we'd like to toggle like so:
+        # "FLAGGING": True,
+        # "COMMENTING": True,
+        # "REMINDERS": False
     }
 
     prod_feature_configuration = {
-        "FLAGGING": False,
-        "COMMENTING": True,
-        "REMINDERS": False
+        # "FLAGGING": False,
+        # "COMMENTING": True,
+        # "REMINDERS": False
     }
 
     @classmethod

--- a/fsd_utils/toggles/__init__.py
+++ b/fsd_utils/toggles/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from . import toggles

--- a/fsd_utils/toggles/__init__.py
+++ b/fsd_utils/toggles/__init__.py
@@ -1,2 +1,0 @@
-# flake8: noqa
-from . import toggles

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -18,11 +18,10 @@ def initialise_toggles_redis_store(flask_app: Flask):
 def create_toggles_client():
     store = RedisFeatureFlagStore(redis_store, base_key='feature')
     client = FeatureFlagClient(store)
-
     return client
 
 
-def load_toggles(feature_configuration: dict, client: FeatureFlagClient):
+def load_toggles(client: FeatureFlagClient):
     for feature, toggle in feature_configuration.items():
         client.create(feature)
         if toggle:

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -1,11 +1,8 @@
 from flipper import FeatureFlagClient, RedisFeatureFlagStore
 from flask_redis import FlaskRedis
+from flask import Flask
 
 redis_store = FlaskRedis()
-
-# Add feature flagging using Redis store
-store = RedisFeatureFlagStore(redis_store, base_key='feature')
-client = FeatureFlagClient(store)
 
 feature_configuration = {
     "FLAGGING": False,
@@ -13,13 +10,20 @@ feature_configuration = {
     "REMINDERS": False
 }
 
-for feature, toggle in feature_configuration.items():
-    try:
+
+def initialise_toggles_redis_store(flask_app: Flask):
+    redis_store.init_app(flask_app)
+
+    
+def create_toggles_client():
+    store = RedisFeatureFlagStore(redis_store, base_key='feature')
+    client = FeatureFlagClient(store)
+
+    return client
+
+
+def load_toggles(feature_configuration: dict, client: FeatureFlagClient):
+    for feature, toggle in feature_configuration.items():
         client.create(feature)
         if toggle:
             client.enable(feature)
-    except AttributeError:
-        continue
-
-def say_hi():
-    return "I have been imported/ installed correctly G!!!!!!!!!!!!!!!!!!!!!!"

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -4,13 +4,6 @@ from flask import Flask
 
 redis_store = FlaskRedis()
 
-feature_configuration = {
-    "FLAGGING": False,
-    "COMMENTING": True,
-    "REMINDERS": False
-}
-
-
 def initialise_toggles_redis_store(flask_app: Flask):
     redis_store.init_app(flask_app)
 
@@ -21,7 +14,7 @@ def create_toggles_client():
     return client
 
 
-def load_toggles(client: FeatureFlagClient):
+def load_toggles(feature_configuration: dict, client: FeatureFlagClient):
     for feature, toggle in feature_configuration.items():
         client.create(feature)
         if toggle:

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -1,24 +1,19 @@
-import redis
 from flipper import FeatureFlagClient, RedisFeatureFlagStore
 from flask_redis import FlaskRedis
-from fsd_utils.healthchecks.checkers import RedisChecker
 
 redis_store = FlaskRedis()
 
-
-r = redis.Redis(host='localhost', port=6379, db=0)
-
 # Add feature flagging using Redis store
 store = RedisFeatureFlagStore(redis_store, base_key='feature')
-features = FeatureFlagClient(store)
+client = FeatureFlagClient(store)
 
 feature_configuration = {
-    "FLAGGING": True,
+    "FLAGGING": False,
     "COMMENTING": True,
     "REMINDERS": False
 }
 
 for feature, toggle in feature_configuration.items():
-    features.create(feature)
+    client.create(feature)
     if toggle:
-        features.enable(feature)
+        client.enable(feature)

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -14,9 +14,12 @@ feature_configuration = {
 }
 
 for feature, toggle in feature_configuration.items():
-    client.create(feature)
-    if toggle:
-        client.enable(feature)
+    try:
+        client.create(feature)
+        if toggle:
+            client.enable(feature)
+    except AttributeError:
+        continue
 
 def say_hi():
     return "I have been imported/ installed correctly G!!!!!!!!!!!!!!!!!!!!!!"

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -17,3 +17,6 @@ for feature, toggle in feature_configuration.items():
     client.create(feature)
     if toggle:
         client.enable(feature)
+
+def say_hi():
+    return "I have been imported/ installed correctly G!!!!!!!!!!!!!!!!!!!!!!"

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -14,7 +14,7 @@ feature_configuration = {
 def initialise_toggles_redis_store(flask_app: Flask):
     redis_store.init_app(flask_app)
 
-    
+
 def create_toggles_client():
     store = RedisFeatureFlagStore(redis_store, base_key='feature')
     client = FeatureFlagClient(store)

--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -1,0 +1,24 @@
+import redis
+from flipper import FeatureFlagClient, RedisFeatureFlagStore
+from flask_redis import FlaskRedis
+from fsd_utils.healthchecks.checkers import RedisChecker
+
+redis_store = FlaskRedis()
+
+
+r = redis.Redis(host='localhost', port=6379, db=0)
+
+# Add feature flagging using Redis store
+store = RedisFeatureFlagStore(redis_store, base_key='feature')
+features = FeatureFlagClient(store)
+
+feature_configuration = {
+    "FLAGGING": True,
+    "COMMENTING": True,
+    "REMINDERS": False
+}
+
+for feature, toggle in feature_configuration.items():
+    features.create(feature)
+    if toggle:
+        features.enable(feature)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.23"
+version = "1.0.24"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "PyJWT[crypto]>=2.4.0",
     "sentry-sdk[flask]>=1.9.9,<2.0.0",
     "requests",
-    "flipper-client>=1.3.1"
+    "flipper-client>=1.3.1",
+    "flask-redis==0.4.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "pytz>=2022.1",
     "PyJWT[crypto]>=2.4.0",
     "sentry-sdk[flask]>=1.9.9,<2.0.0",
-    "requests"
+    "requests",
+    "flipper-client>=1.3.1"
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ sqlalchemy==1.4.39
 flask-redis==0.4.0
 pytest
 pytest-mock
+flipper-client==1.3.1


### PR DESCRIPTION
FS-2277: Spike: Feature Toggles


### Change description
Added the toggles module to utils that contains the functions to initialize the redis store, create a redis client and load it with the toggles using a pre-defined feature_configuration.

### How to test
checkout to this branch along with [this ](https://github.com/communitiesuk/funding-service-design-docker-runner/pull/28)in docker runner and [this ](https://github.com/communitiesuk/funding-service-design-assessment/pull/191)in assessment and see flagging functionality hidden from the user. (More info on running this E2E can be found in the description of the above assessment PR^.

See [this doc](https://digital.dclg.gov.uk/confluence/display/FS/Feature+Toggles+in+FSD) for more information on methodology, set up and how to use.
