### PR TITLE
FS-1200: exclude performance tests from sentry request sampling

### DIFF
--- a/fsd_utils/sentry/init_sentry.py
+++ b/fsd_utils/sentry/init_sentry.py
@@ -7,7 +7,10 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 def _traces_sampler(sampling_context):
     wsgi_environ = sampling_context.get("wsgi_environ")
-    if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
+    if wsgi_environ and (
+        wsgi_environ.get("PATH_INFO") == "/healthcheck"
+        or wsgi_environ.get("HTTP_USER_AGENT" == "locust performance tests")
+    ):
         # Drop this transaction, by setting its sample rate to 0%
         return 0
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.23"
+version = "1.0.24"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
### Change description
Exclude performance tests from sentry request sampling as processing large amounts of requests causes us to exceed quotas.

### How to test
Was tested manually by dumping out sentry sampling context to work out correct value from event to filter.

