### PR TITLE
BAU bump version for fs-2277-toggles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.24"
+version = "1.0.25"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
### Change description
Bumping version to 1.0.25 after merging fs-2277-toggles, did not originally bump the version high enough.