### PR TITLE
fs-2514-multifund-redis-setup

### DIFF
--- a/fsd_utils/toggles/toggles.py
+++ b/fsd_utils/toggles/toggles.py
@@ -3,7 +3,7 @@ from flask_redis import FlaskRedis
 from flipper import FeatureFlagClient
 from flipper import RedisFeatureFlagStore
 
-redis_store = FlaskRedis()
+redis_store = FlaskRedis(config_prefix="TOGGLES")
 
 
 def initialise_toggles_redis_store(flask_app: Flask):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "1.0.29"
+version = "1.0.30"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
Adding config prefix to FlaskRedis object to allow toggle client to use the appropriate redi uri