### PR TITLE
PAB-328: add return_app param to login_required decorator

### DIFF
--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -6,6 +6,8 @@ To use this utility please ensure that all the
 in the environment of the application that is using
 this utility.
 """
+import enum
+
 config_var_auth_host = "AUTHENTICATOR_HOST"
 config_var_user_token_cookie_name = "FSD_USER_TOKEN_COOKIE_NAME"
 config_var_rs256_public_key = "RSA256_PUBLIC_KEY"
@@ -16,3 +18,7 @@ azure_ad_role_map = {
     "Assessor": "ASSESSOR",
     "Commenter": "COMMENTER",
 }
+
+
+class SupportedApp(enum.Enum):
+    POST_AWARD_FRONTEND = "post-award-frontend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -207,3 +207,62 @@ class TestAuthentication:
             mock_request.location
             == "https://authenticator/service/user?roles_required=COMMENTER"
         )
+
+    def test_login_required_with_return_app_redirects_to_signed_out_without_token(
+        self, flask_test_client
+    ):
+        """
+        GIVEN a flask_test_client and
+            route decorated with @login_required decorator with the "return_app" parameter set to "post-award-frontend"
+        WHEN a request is made without any "fsd-user-token" cookie
+        THEN the route redirects to the authenticator /sessions/sign-out url with correct return_app query param
+        :param flask_test_client:
+        """
+        mock_request = flask_test_client.get("/mock_login_requested_return_app_route")
+
+        assert mock_request.status_code == 302
+        assert (
+            mock_request.location
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+        )
+
+    def test_login_required_with_return_app_redirects_to_signed_out_with_invalid_token(
+        self, flask_test_client
+    ):
+        """
+        GIVEN a flask_test_client and
+            route decorated with @login_required decorator with the "return_app" parameter set to "post-award-frontend"
+        WHEN a request is made with a correctly formatted
+            but invalidly signed "fsd-user-token" cookie
+        THEN the route redirects to the authenticator /sessions/sign-out url with correct return_app query param
+        :param flask_test_client:
+        """
+        invalid_token = self._create_invalid_token()
+        flask_test_client.set_cookie("localhost", "fsd-user-token", invalid_token)
+        mock_request = flask_test_client.get("/mock_login_requested_return_app_route")
+
+        assert mock_request.status_code == 302
+        assert (
+            mock_request.location
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+        )
+
+    def test_login_required_with_return_app_sets_user_attributes_with_valid_token(
+        self, flask_test_client
+    ):
+        """
+        GIVEN a flask_test_client and
+            route decorated with @login_required decorator with the "return_app" parameter set to "post-award-frontend"
+        WHEN a request is made with a correctly formatted
+            and signed "fsd-user-token" cookie
+        THEN the route returns with the g variable "logout_url" set correctly
+        :param flask_test_client:
+        """
+        valid_token = self._create_valid_token()
+        flask_test_client.set_cookie("localhost", "fsd-user-token", valid_token)
+        mock_request = flask_test_client.get("/mock_login_requested_return_app_route")
+        assert mock_request.status_code == 200
+        assert (
+            mock_request.json["logout_url"]
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+        )


### PR DESCRIPTION
https://trello.com/c/tQ3rDYzh/328-implement-authentication-changes-into-front-end-auth-utils-and-docker-runner

### Change description
Adds a new parameter `return_app` to the `login_required` decorator that enables authenticator to redirect back to FSD applications other than Assessment

- [X] Unit tests and other appropriate tests added or updated
- [NA] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
