### PR TITLE
FS-2990 & 2989: Devolved authorities & fund specific access

### DIFF
--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -14,9 +14,22 @@ config_var_rs256_public_key = "RSA256_PUBLIC_KEY"
 signout_route = "/sessions/sign-out"
 user_route = "/service/user"
 azure_ad_role_map = {
-    "LeadAssessor": "LEAD_ASSESSOR",
-    "Assessor": "ASSESSOR",
-    "Commenter": "COMMENTER",
+    # deprecated roles
+    "LeadAssessor": "COF_LEAD_ASSESSOR",
+    "Assessor": "COF_ASSESSOR",
+    "Commenter": "COF_COMMENTER",
+    # COF specific roles
+    "COF_Lead_Assessor": "COF_LEAD_ASSESSOR",
+    "COF_Assessor": "COF_ASSESSOR",
+    "COF_Commenter": "COF_COMMENTER",
+    "COF_England": "COF_ENGLAND",
+    "COF_NorthernIreland": "COF_NORTHERNIRELAND",  # TODO: what did they call this?
+    "COF_Scotland": "COF_SCOTLAND",
+    "COF_Wales": "COF_WALES",
+    # NSTF specific roles
+    "NSTF_Lead_Assessor": "NSTF_LEAD_ASSESSOR",
+    "NSTF_Assessor": "NSTF_ASSESSOR",
+    "NSTF_Commenter": "NSTF_COMMENTER",
 }
 
 

--- a/fsd_utils/authentication/models.py
+++ b/fsd_utils/authentication/models.py
@@ -4,10 +4,11 @@ Data models for authentication
 from dataclasses import dataclass
 from os import getenv
 from typing import List
+from typing import Mapping
 
 from sentry_sdk import set_user
 
-from .utils import get_highest_role
+from .utils import get_highest_role_map
 
 
 @dataclass
@@ -15,7 +16,7 @@ class User:
     full_name: str
     email: str
     roles: List[str]
-    highest_role: str
+    highest_role_map: Mapping[str, str]
 
     @classmethod
     def set_with_token(cls, token_payload):
@@ -35,5 +36,5 @@ class User:
             full_name=full_name,
             email=email,
             roles=roles,
-            highest_role=get_highest_role(roles),
+            highest_role_map=get_highest_role_map(roles),
         )

--- a/fsd_utils/authentication/utils.py
+++ b/fsd_utils/authentication/utils.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Mapping
 
 import jwt as jwt
 from flask import current_app
@@ -16,8 +17,28 @@ def validate_token_rs256(token):
     return _validate_token(token, key, algorithms=["RS256"])
 
 
-def get_highest_role(roles: List[str]):
-    if roles and len(roles) > 0:
-        for _, role in azure_ad_role_map.items():
-            if role in roles:
-                return role
+_ROLE_HIERARCHY = [
+    "LEAD_ASSESSOR",
+    "ASSESSOR",
+    "COMMENTER",
+]
+
+
+def get_highest_role_map(roles: list[str]) -> Mapping[str, str]:
+    roles_with_fund_prefix = tuple(f"_{rh}" for rh in _ROLE_HIERARCHY)
+    filtered_roles = [r for r in roles if r.endswith(roles_with_fund_prefix)]
+
+    fund_short_name_to_roles_list = {}
+    for role in filtered_roles:
+        fund_short_name, sub_role = role.split("_", 1)
+        if fund_short_name in fund_short_name_to_roles_list:
+            fund_short_name_to_roles_list[fund_short_name].append(sub_role)
+        else:
+            fund_short_name_to_roles_list[fund_short_name] = [sub_role]
+
+    fund_short_name_to_highest_role = {}
+    for fund_short_name, roles_list in fund_short_name_to_roles_list.items():
+        highest_role, *_ = sorted(roles_list, key=lambda x: _ROLE_HIERARCHY.index(x))
+        fund_short_name_to_highest_role[fund_short_name] = highest_role
+
+    return fund_short_name_to_highest_role

--- a/fsd_utils/authentication/utils.py
+++ b/fsd_utils/authentication/utils.py
@@ -1,10 +1,8 @@
-from typing import List
 from typing import Mapping
 
 import jwt as jwt
 from flask import current_app
 
-from .config import azure_ad_role_map
 from .config import config_var_rs256_public_key
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,8 +92,8 @@ def flask_test_development_client():
                 "DEBUG_USER": {
                     "full_name": "Development User",
                     "email": "dev@example.com",
-                    "roles": ["ADMIN", "TEST"],
-                    "highest_role": "ADMIN",
+                    "roles": ["COF_ADMIN", "COF_TEST"],
+                    "highest_role_map": {"COF": "ADMIN"},
                 },
                 "FSD_USER_TOKEN_COOKIE_NAME": "fsd-user-token",
                 "AUTHENTICATOR_HOST": "https://authenticator",
@@ -128,8 +128,8 @@ def mock_login_required_route():
         "user": User(
             email="test@example.com",
             full_name="Test User",
-            highest_role="LEAD_ASSESSOR",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"]
+            highest_role_map={"COF": "LEAD_ASSESSOR"},
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"]
         )
     :return: the Flask g variable serialised as a dict/json
     """
@@ -149,8 +149,8 @@ def mock_login_requested_route():
         "user": User(
             email="test@example.com",
             full_name="Test User",
-            highest_role="LEAD_ASSESSOR",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"]
+            highest_role_map={"COF": "LEAD_ASSESSOR"},
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"]
         )
     and a non logged in user to have the Flask request g variables
     set as below:
@@ -164,7 +164,7 @@ def mock_login_requested_route():
     return vars(g)
 
 
-@login_required(roles_required=["COMMENTER"])
+@login_required(roles_required=["COF_COMMENTER"])
 def mock_login_required_roles_route():
     """
     A mock route function decorated with
@@ -182,15 +182,15 @@ def mock_login_required_roles_route():
         "user": User(
             email="test@example.com",
             full_name="Test User",
-            highest_role="LEAD_ASSESSOR",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"]
+            highest_role_map={"COF": "LEAD_ASSESSOR"},
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"]
         )
     :return: the Flask g variable serialised as a dict/json
     """
     return vars(g)
 
 
-@login_required(roles_required=["ADMIN", "TEST"])
+@login_required(roles_required=["COF_ADMIN", "COF_TEST"])
 def mock_login_required_admin_roles_route():
     """
     A mock route function decorated with
@@ -208,8 +208,8 @@ def mock_login_required_admin_roles_route():
         "user": User(
             email="test@example.com",
             full_name="Test User",
-            highest_role="LEAD_ASSESSOR",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"]
+            highest_role_map={"COF": "LEAD_ASSESSOR"},
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"]
         )
     :return: the Flask g variable serialised as a dict/json
     """
@@ -230,8 +230,8 @@ def mock_login_requested_return_app_route():
         "user": User(
             email="test@example.com",
             full_name="Test User",
-            highest_role="LEAD_ASSESSOR",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"]
+            highest_role_map={"COF": "LEAD_ASSESSOR"},
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"]
         )
     and a non logged in user to have the Flask request g variables
     set as below:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -9,7 +9,7 @@ class TestAuthentication:
         "accountId": "test-user",
         "email": "test@example.com",
         "fullName": "Test User",
-        "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+        "roles": ["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
     }
     expected_valid_g_attributes = {
         "is_authenticated": True,
@@ -18,8 +18,8 @@ class TestAuthentication:
         "user": {
             "email": "test@example.com",
             "full_name": "Test User",
-            "highest_role": "LEAD_ASSESSOR",
-            "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+            "highest_role_map": {"COF": "LEAD_ASSESSOR"},
+            "roles": ["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
         },
     }
 
@@ -115,7 +115,7 @@ class TestAuthentication:
         assert mock_request.status_code == 302
         assert (
             mock_request.location
-            == "https://authenticator/service/user?roles_required=ADMIN|TEST"
+            == "https://authenticator/service/user?roles_required=COF_ADMIN|COF_TEST"
         )
 
     def test_login_required_roles_sets_user_attributes_if_user_has_roles(
@@ -205,7 +205,7 @@ class TestAuthentication:
         assert mock_request.status_code == 302
         assert (
             mock_request.location
-            == "https://authenticator/service/user?roles_required=COMMENTER"
+            == "https://authenticator/service/user?roles_required=COF_COMMENTER"
         )
 
     def test_login_required_with_return_app_redirects_to_signed_out_without_token(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+from fsd_utils.authentication.utils import get_highest_role_map
+
+
+def test_get_highest_role_map():
+    roles = [
+        "COF_ASSESSOR",  # highest role is assessor
+        "COF_COMMENTER",
+        "COF_SCOTLAND",
+        "COF_ENGLAND",
+        "COF_WALES",
+        "COF_NORTHERNIRELAND",
+        "NSTF_LEAD_ASSESSOR",  # highest role is lead assessor
+        "NSTF_ASSESSOR",
+        "NSTF_COMMENTER",
+        "MOCKFUND_COMMENTER",  # highest role is commenter
+        "INVALIDFUND_INVALIDROLE",  # invalid role is ignored
+    ]
+
+    result = get_highest_role_map(roles)
+
+    assert "INVALIDFUND" not in result
+    assert result == {
+        "COF": "ASSESSOR",
+        "NSTF": "LEAD_ASSESSOR",
+        "MOCKFUND": "COMMENTER",
+    }


### PR DESCRIPTION
### Change description

The `azure_ad_role_map` has been updated based on the theoretical mappings from Azure AD - these may be wrong and need changed depending on what has been configured for us, the old roles are now mapped to COF.

Instead of having a `highest_role`, we now have a `highest_role_map` which maps `fund_short_name -> highest_role`, this is because different users may have different highest roles between funds, so we need a way to track them.


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines

### Other related PRs

https://github.com/communitiesuk/funding-service-design-account-store/pull/96
https://github.com/communitiesuk/funding-service-design-assessment-store/pull/198
https://github.com/communitiesuk/funding-service-design-assessment/pull/275
https://github.com/communitiesuk/funding-service-design-authenticator/pull/169
