### PR TITLE
remove deprecated config

### DIFF
--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -13,24 +13,6 @@ config_var_user_token_cookie_name = "FSD_USER_TOKEN_COOKIE_NAME"
 config_var_rs256_public_key = "RSA256_PUBLIC_KEY"
 signout_route = "/sessions/sign-out"
 user_route = "/service/user"
-azure_ad_role_map = {
-    # deprecated roles
-    "LeadAssessor": "COF_LEAD_ASSESSOR",
-    "Assessor": "COF_ASSESSOR",
-    "Commenter": "COF_COMMENTER",
-    # COF specific roles
-    "COF_Lead_Assessor": "COF_LEAD_ASSESSOR",
-    "COF_Assessor": "COF_ASSESSOR",
-    "COF_Commenter": "COF_COMMENTER",
-    "COF_England": "COF_ENGLAND",
-    "COF_NorthernIreland": "COF_NORTHERNIRELAND",  # TODO: what did they call this?
-    "COF_Scotland": "COF_SCOTLAND",
-    "COF_Wales": "COF_WALES",
-    # NSTF specific roles
-    "NSTF_Lead_Assessor": "NSTF_LEAD_ASSESSOR",
-    "NSTF_Assessor": "NSTF_ASSESSOR",
-    "NSTF_Commenter": "NSTF_COMMENTER",
-}
 
 
 class SupportedApp(enum.Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-version = "2.0.22"
+version = "2.0.23"
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
 ]


### PR DESCRIPTION
we no longer need a check against valid roles as the deprecated roles are no longer being used. 