### PR TITLE
fs-4035 handling numbers passed in as strings

### DIFF
--- a/fsd_utils/eoi/evaluate_eoi_response.py
+++ b/fsd_utils/eoi/evaluate_eoi_response.py
@@ -22,7 +22,8 @@ def _evaluate_with_supplied_operators(
         supplied_answer (any): Answer supplied to this question
 
     Raises:
-        ValueError: If the operator from the schema is not supported, or if the supplied answer cannot be converted to a float
+        ValueError: If the operator from the schema is not supported, or if the supplied answer
+        cannot be converted to a float
 
     Returns:
         tuple[Eoi_Decision, list]: Tuple of the decision and the caveats (if there are any)
@@ -39,7 +40,8 @@ def _evaluate_with_supplied_operators(
             answer_as_number = float(supplied_answer)
         except ValueError:
             raise ValueError(
-                f"Answer {supplied_answer} is not numeric so cannot be used with this condition: [{ec['operator']} {ec['compareValue']}]"
+                f"Answer {supplied_answer} is not numeric so cannot be used with this condition: "
+                f"[{ec['operator']} {ec['compareValue']}]"
             )
 
         # construct evaluation expression

--- a/fsd_utils/eoi/evaluate_eoi_response.py
+++ b/fsd_utils/eoi/evaluate_eoi_response.py
@@ -15,13 +15,14 @@ def _evaluate_with_supplied_operators(
 ) -> tuple[Eoi_Decision, list]:
     """Evaluates an expression built from the operator in the schmea, the value to compare, and the supplied answer.
     Uses the result of the evaluation to return a decision and applicable caveats
+    Casts the value to an integer for comparison
 
     Args:
         conditions_to_evaluate (list): List of conditions from schema
         supplied_answer (any): Answer supplied to this question
 
     Raises:
-        ValueError: If the operator from the schema is not supported
+        ValueError: If the operator from the schema is not supported, or if the supplied answer cannot be converted to a float
 
     Returns:
         tuple[Eoi_Decision, list]: Tuple of the decision and the caveats (if there are any)
@@ -33,11 +34,19 @@ def _evaluate_with_supplied_operators(
         if ec["operator"] not in VALID_OPERATORS:
             raise ValueError(f"Operator {ec['operator']} is not supported")
 
+        # validate that answer is numeric
+        try:
+            answer_as_number = float(supplied_answer)
+        except ValueError:
+            raise ValueError(
+                f"Answer {supplied_answer} is not numeric so cannot be used with this condition: [{ec['operator']} {ec['compareValue']}]"
+            )
+
         # construct evaluation expression
         expression = f"answer {ec['operator']} value"
 
         # evaluation using supplied operator
-        if eval(expression, {"answer": supplied_answer, "value": ec["compareValue"]}):
+        if eval(expression, {"answer": answer_as_number, "value": ec["compareValue"]}):
             # We met this condition
             decision = max(decision, ec["result"])
             if ec["caveat"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "2.0.39"
+version = "2.0.40"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/tests/test_eoi.py
+++ b/tests/test_eoi.py
@@ -368,7 +368,20 @@ def test_no_questions_hit_conditions():
     assert result["caveats"] == []
 
 
-@pytest.mark.parametrize("supplied_answer", ["a1", "--2", "-a3.356345", "400099.asdf", "£234", "£234234.00", "hello there", "45,6", "123£$%^&*()''`\""])
+@pytest.mark.parametrize(
+    "supplied_answer",
+    [
+        "a1",
+        "--2",
+        "-a3.356345",
+        "400099.asdf",
+        "£234",
+        "£234234.00",
+        "hello there",
+        "45,6",
+        "123£$%^&*()''`\"",
+    ],
+)
 def test_answer_validation_failure(supplied_answer):
     condition = {
         "operator": "<",
@@ -379,7 +392,11 @@ def test_answer_validation_failure(supplied_answer):
     with pytest.raises(ValueError):
         _evaluate_with_supplied_operators([condition], supplied_answer)
 
-@pytest.mark.parametrize("supplied_answer", ["1", 1, "-2", "-3.356345", "400099.234234", 3434.5656, 0, "00000", 0000])
+
+@pytest.mark.parametrize(
+    "supplied_answer",
+    ["1", 1, "-2", "-3.356345", "400099.234234", 3434.5656, 0, "00000", 0000],
+)
 def test_answer_validation_success(supplied_answer):
     condition = {
         "operator": "<",


### PR DESCRIPTION
Fix that casts any values passed to the operator evaluation function to a number as they are sent as strings in the form json responses