### PR TITLE
FS-4253: Add translation to answer formatters

### DIFF
--- a/fsd_utils/mapping/application/application_utils.py
+++ b/fsd_utils/mapping/application/application_utils.py
@@ -4,15 +4,36 @@ from io import StringIO
 
 from flask import current_app
 
+EN, CY = "en", "cy"
+SUPPORTED_LANGUAGES = {EN, CY}
 
-def convert_bool_value(data):
+NOT_PROVIDED = {
+    EN: "Not provided",
+    CY: "Heb ei ddarparu",
+}
+
+YES = {
+    EN: "Yes",
+    CY: "Ydw",
+}
+
+NO = {
+    EN: "No",
+    CY: "Nac ydw",
+}
+
+
+def convert_bool_value(data, language=EN):
+    if not language and language not in SUPPORTED_LANGUAGES:
+        language = EN
+
     try:
 
         def convert_values(value):
             if value is None or value == "None":
-                return "Not provided"
+                return NOT_PROVIDED[language]
             if isinstance(value, bool):
-                return "Yes" if value else "No"
+                return YES[language] if value else NO[language]
             else:
                 return value
 
@@ -31,10 +52,13 @@ def convert_bool_value(data):
         current_app.logger.error(f"Could not convert boolean values, {e}")
 
 
-def format_answer(answer):
+def format_answer(answer, language=EN):
+    if not language and language not in SUPPORTED_LANGUAGES:
+        language = EN
+
     try:
         if answer is None or answer == "None":
-            return "Not provided"
+            return NOT_PROVIDED[language]
 
         if "null" in answer:
             return re.sub(r"\s*null\s*,?", "", answer)
@@ -214,7 +238,7 @@ def format_date_month_year(answer):
         month_name = calendar.month_name[int(month)]
         if month_name:
             date = answer_text[2] if len(answer_text[2]) <= 2 else answer_text[0]
-            date = f"{'0'+date if len(date)==1 else date}"
+            date = f"{'0' + date if len(date) == 1 else date}"
             year = answer_text[0] if len(answer_text[0]) == 4 else answer_text[2]
             return f"{date} {month_name} {year}"
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "2.0.41"
+version = "2.0.42"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/tests/test_mapping_application.py
+++ b/tests/test_mapping_application.py
@@ -15,19 +15,40 @@ from tests.test_data_utils import test_data_sort_questions_answers
 
 
 @pytest.mark.parametrize(
-    "input_data, expected_response",
+    "input_data, language, expected_response",
     [
-        (True, "Yes"),
-        (False, "No"),
-        (["address", True], ["address", "Yes"]),
-        ((["address", False], ["address", "No"])),
-        (None, "Not provided"),
-        ([["name", True], ["name", "Yes"]]),
-        ([["name", False], ["name", "No"]]),
+        (True, "en", "Yes"),
+        (True, None, "Yes"),
+        (True, "", "Yes"),
+        (True, "cy", "Ydw"),
+        (False, "en", "No"),
+        (False, None, "No"),
+        (False, "", "No"),
+        (False, "cy", "Nac ydw"),
+        (["address", True], "en", ["address", "Yes"]),
+        (["address", True], None, ["address", "Yes"]),
+        (["address", True], "", ["address", "Yes"]),
+        (["address", True], "cy", ["address", "Ydw"]),
+        ((["address", False], "en", ["address", "No"])),
+        ((["address", False], None, ["address", "No"])),
+        ((["address", False], "", ["address", "No"])),
+        ((["address", False], "cy", ["address", "Nac ydw"])),
+        (None, "en", "Not provided"),
+        (None, None, "Not provided"),
+        (None, "", "Not provided"),
+        (None, "cy", "Heb ei ddarparu"),
+        ([["name", True], "en", ["name", "Yes"]]),
+        ([["name", True], None, ["name", "Yes"]]),
+        ([["name", True], "", ["name", "Yes"]]),
+        ([["name", True], "cy", ["name", "Ydw"]]),
+        ([["name", False], "en", ["name", "No"]]),
+        ([["name", False], None, ["name", "No"]]),
+        ([["name", False], "", ["name", "No"]]),
+        ([["name", False], "cy", ["name", "Nac ydw"]]),
     ],
 )
-def test_convert_bool_values(input_data, expected_response):
-    response = convert_bool_value(input_data)
+def test_convert_bool_values(input_data, expected_response, language):
+    response = convert_bool_value(input_data, language)
     assert response == expected_response
 
 


### PR DESCRIPTION
### Change description

- Add language to methods used for formatting answers
- Update unit tests to include all cases of EN/CY
- Note, the reason for hardcoded translations are that these are used in places without pybabel (i.e application store)

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
