### PR TITLE
fs-3530 removing eoi from decision naming

### DIFF
--- a/fsd_utils/__init__.py
+++ b/fsd_utils/__init__.py
@@ -7,8 +7,8 @@ from fsd_utils import toggles
 from fsd_utils.config.commonconfig import CommonConfig  # noqa
 from fsd_utils.config.configclass import configclass  # noqa
 from fsd_utils.config.notify_constants import NotifyConstants  # noqa
-from fsd_utils.eoi.evaluate_eoi_response import Eoi_Decision
-from fsd_utils.eoi.evaluate_eoi_response import evaluate_eoi_response
+from fsd_utils.decision.evaluate_response_against_schema import Decision
+from fsd_utils.decision.evaluate_response_against_schema import evaluate_response
 from fsd_utils.locale_selector.set_lang import LanguageSelector
 from fsd_utils.mapping.application.application_utils import generate_text_of_application
 from fsd_utils.mapping.application.qa_mapping import (
@@ -34,7 +34,7 @@ __all__ = [
     toggles,
     generate_text_of_application,
     extract_questions_and_answers,
-    evaluate_eoi_response,
-    Eoi_Decision,
+    evaluate_response,
+    Decision,
     services,
 ]

--- a/fsd_utils/decision/evaluate_response_against_schema.py
+++ b/fsd_utils/decision/evaluate_response_against_schema.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 
-class Eoi_Decision(IntEnum):
+class Decision(IntEnum):
     PASS = 0
     PASS_WITH_CAVEATS = 1
     FAIL = 2
@@ -12,7 +12,7 @@ VALID_OPERATORS = ["<", "<=", "==", ">=", ">"]
 
 def _evaluate_with_supplied_operators(
     conditions_to_evaluate: list, supplied_answer: any
-) -> tuple[Eoi_Decision, list]:
+) -> tuple[Decision, list]:
     """Evaluates an expression built from the operator in the schmea, the value to compare, and the supplied answer.
     Uses the result of the evaluation to return a decision and applicable caveats
     Casts the value to an integer for comparison
@@ -26,9 +26,9 @@ def _evaluate_with_supplied_operators(
         cannot be converted to a float
 
     Returns:
-        tuple[Eoi_Decision, list]: Tuple of the decision and the caveats (if there are any)
+        tuple[Decision, list]: Tuple of the decision and the caveats (if there are any)
     """
-    decision = Eoi_Decision.PASS
+    decision = Decision.PASS
     caveats = []
     for ec in conditions_to_evaluate:
         # validate supplied operator
@@ -54,14 +54,14 @@ def _evaluate_with_supplied_operators(
             if ec["caveat"]:
                 caveats.append(ec["caveat"])
 
-    if decision == Eoi_Decision.FAIL:
+    if decision == Decision.FAIL:
         return decision, []  # don't return caveats for failure
     else:
         return decision, caveats
 
 
-def evaluate_eoi_response(schema: dict, forms: dict) -> dict:
-    """Takes in an EOI schema and a set of forms containing responses, then makes a decision on the EOI outcome
+def evaluate_response(schema: dict, forms: dict) -> dict:
+    """Takes in a decision schema and a set of forms containing responses, then makes a decision on the outcome
 
     Args:
         schema (dict): Schema defining decisions based on answers
@@ -69,11 +69,11 @@ def evaluate_eoi_response(schema: dict, forms: dict) -> dict:
 
     Returns:
         dict: Results of decision:
-            decision: value of Eoi_Decision ENUM
+            decision: value of Decision ENUM
             caveats: list of strings of caveats for answers if decision is 'Pass with caveats', otherwise empty list
 
     """
-    result = {"decision": Eoi_Decision.PASS, "caveats": []}
+    result = {"decision": Decision.PASS, "caveats": []}
 
     # Loop through every form, then every response in that form
     for form in forms:
@@ -112,7 +112,7 @@ def evaluate_eoi_response(schema: dict, forms: dict) -> dict:
                         result["caveats"] += caveats
 
                     # If we failed on this question, we don't need to evaluate any further, just return a fail
-                    if result["decision"] == Eoi_Decision.FAIL:
-                        return {"decision": Eoi_Decision.FAIL, "caveats": []}
+                    if result["decision"] == Decision.FAIL:
+                        return {"decision": Decision.FAIL, "caveats": []}
 
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "2.0.44"
+version = "2.0.45"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },


### PR DESCRIPTION
### Change description
I think we will need to use the mechanisms for EOI to evaluate eligibility responses as well, so just updating the name to remove EOI and make it a generic `decision` feature

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
