### PR TITLE
fs-3993 removing alert for invalid language

### DIFF
--- a/fsd_utils/locale_selector/get_lang.py
+++ b/fsd_utils/locale_selector/get_lang.py
@@ -1,4 +1,5 @@
 from babel import negotiate_locale
+from flask import current_app
 from flask import request
 from fsd_utils import CommonConfig
 
@@ -9,9 +10,10 @@ def get_lang():
     language_from_query_args = request.args.get("lang")
     if language_from_query_args:
         if language_from_query_args not in ["cy", "en"]:
-            raise ValueError(
-                "Invalid language code. Supported codes are 'cy' and 'en'."
+            current_app.logger.warning(
+                f"Invalid language code {language_from_query_args}. Supported codes are 'cy' and 'en'."
             )
+            return "en"
         else:
             return language_from_query_args
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "2.0.47"
+version = "2.0.48"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/tests/test_get_lang.py
+++ b/tests/test_get_lang.py
@@ -1,4 +1,3 @@
-import pytest
 from fsd_utils.locale_selector.get_lang import get_lang
 
 
@@ -9,13 +8,7 @@ class TestGetLang:
 
     def test_get_lang_query_arg_invalid(self, flask_test_client):
         with flask_test_client.application.test_request_context("/?lang=fr"):
-            with pytest.raises(
-                ValueError,
-                match=(
-                    "Invalid language code. Supported codes" + " are 'cy' and 'en'."
-                ),
-            ):
-                get_lang()
+            assert get_lang() == "en"
 
     def test_get_lang_cookie_preference(self, flask_test_client):
         with flask_test_client.application.test_request_context(


### PR DESCRIPTION
### Change description
We get a lot of sentry errors about invalid language code - changing this to a warning instead of an exception, and defaulting to english which will stop the sentry errors

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

