### PR TITLE
FS-3535 : adding a custom s3 key for the message that sent through extended client

### DIFF
--- a/fsd_utils/services/aws_extended_client.py
+++ b/fsd_utils/services/aws_extended_client.py
@@ -93,7 +93,7 @@ class SQSExtendedClient:
             },
         }
         message_body, message_attributes = self._store_message_in_s3(
-            message, sqs_message_attributes
+            message, sqs_message_attributes, extra_attributes
         )
         # add extra message attributes (if provided)
         if extra_attributes:
@@ -289,12 +289,13 @@ class SQSExtendedClient:
         return message_body
 
     def _store_message_in_s3(
-        self, message_body: str, message_attributes: dict
+        self, message_body: str, message_attributes: dict, extra_attributes: dict
     ) -> (str, dict):
         """
         Responsible for storing a message payload in a S3 Bucket
         :message_body: A UTF-8 encoded version of the message body
-        :message_attributes: A dictionary consisting of message attributes.
+        :message_attributes: A dictionary consisting of message attributes
+        :extra_attributes: A dictionary consisting of message attributes
         Each message attribute consists of the name (key) along with a
         type and value of the message body. The following types are supported
         for message attributes: StringValue, BinaryValue and DataType.
@@ -317,7 +318,7 @@ class SQSExtendedClient:
             message_attributes[RESERVED_ATTRIBUTE_NAME] = attribute_value
 
             # S3 Key should either be a constant or be a random uuid4 string.
-            s3_key = get_s3_key(message_attributes)
+            s3_key = get_s3_key(message_attributes, extra_attributes)
 
             # Adding the object into the bucket
             response = self.s3_client.put_object(

--- a/fsd_utils/services/aws_sqs_extended_client_util.py
+++ b/fsd_utils/services/aws_sqs_extended_client_util.py
@@ -15,7 +15,7 @@ MESSAGE_POINTER_CLASS = "software.amazon.payloadoffloading.PayloadS3Pointer"
 def get_message_attributes_size(message_attributes: dict) -> int:
     """
     Responsible for calculating the size, in bytes, of the message attributes
-    of a given message payload.
+    of a given message payload
     :message_attributes: A dictionary consisting of message attributes.
     Each message attribute consists of the name (key) along with a
     type and value of the message body. The following types are supported
@@ -93,11 +93,12 @@ def check_message_attributes(message_attributes: dict) -> None:
     return
 
 
-def get_s3_key(message_attributes: dict) -> str:
+def get_s3_key(message_attributes: dict, extra_attributes: dict) -> str:
     """
     Responsible for checking if the S3 Key exists in the
     message_attributes
-    :message_attributes: A dictionary consisting of message attributes.
+    :message_attributes: A dictionary consisting of message attributes
+    :extra_attributes: A dictionary consisting of message attributes
     Each message attribute consists of the name (key) along with a
     type and value of the message body. The following types are supported
     for message attributes: StringValue, BinaryValue and DataType.
@@ -105,6 +106,10 @@ def get_s3_key(message_attributes: dict) -> str:
 
     if S3_KEY_ATTRIBUTE_NAME in message_attributes:
         return message_attributes[S3_KEY_ATTRIBUTE_NAME]["StringValue"]
+    elif extra_attributes and S3_KEY_ATTRIBUTE_NAME in extra_attributes:
+        return (
+            extra_attributes[S3_KEY_ATTRIBUTE_NAME]["StringValue"] + "/" + str(uuid4())
+        )
     return str(uuid4())
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "2.0.49"
+version = "2.0.50"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3535


### Change description
adding the capability to SQS extended client's S3 to have custom S3Key

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
