### PR TITLE
FPASF-376: add request path to sign-out url

### DIFF
--- a/fsd_utils/authentication/decorators.py
+++ b/fsd_utils/authentication/decorators.py
@@ -74,7 +74,7 @@ def _build_logout_url(return_app: SupportedApp | None):
         return (
             authenticator_host
             + signout_route
-            + f"?{urlencode({'return_app': return_app.value})}"
+            + f"?{urlencode({'return_app': return_app.value, 'return_path': request.path})}"
         )
     else:
         return authenticator_host + signout_route

--- a/fsd_utils/authentication/decorators.py
+++ b/fsd_utils/authentication/decorators.py
@@ -6,6 +6,7 @@ from flask import abort
 from flask import current_app
 from flask import g
 from flask import redirect
+from flask import Request
 from flask import request
 from fsd_utils.authentication.utils import validate_token_rs256
 from jwt import ExpiredSignatureError
@@ -60,6 +61,11 @@ def _check_access_token(return_app: SupportedApp | None = None, auto_redirect=Tr
         return False
 
 
+def _build_return_path(request: Request):
+    query_string = ("?" + request.query_string.decode()) if request.query_string else ""
+    return request.path + query_string
+
+
 def _build_logout_url(return_app: SupportedApp | None):
     if override := current_app.config.get(config_var_logout_url_override):
         return override
@@ -69,7 +75,7 @@ def _build_logout_url(return_app: SupportedApp | None):
         return (
             authenticator_host
             + signout_route
-            + f"?{urlencode({'return_app': return_app.value, 'return_path': request.path})}"
+            + f"?{urlencode({'return_app': return_app.value, 'return_path': _build_return_path(request)})}"
         )
     else:
         return authenticator_host + signout_route

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "3.0.2"
+version = "4.0.1"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -247,6 +247,19 @@ class TestAuthentication:
             == "https://authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Fmock_login_requested_return_app_route"  # noqa: E501
         )
 
+    def test_login_required_with_return_app_return_path_retains_query_string(
+        self, flask_test_client
+    ):
+        mock_request = flask_test_client.get(
+            "/mock_login_requested_return_app_route?foo=bar"
+        )
+
+        assert mock_request.status_code == 302
+        assert (
+            mock_request.location
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Fmock_login_requested_return_app_route%3Ffoo%3Dbar"  # noqa: E501
+        )
+
     def test_login_required_with_return_app_sets_user_attributes_with_valid_token(
         self, flask_test_client
     ):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -223,7 +223,7 @@ class TestAuthentication:
         assert mock_request.status_code == 302
         assert (
             mock_request.location
-            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Fmock_login_requested_return_app_route"  # noqa: E501
         )
 
     def test_login_required_with_return_app_redirects_to_signed_out_with_invalid_token(
@@ -244,7 +244,7 @@ class TestAuthentication:
         assert mock_request.status_code == 302
         assert (
             mock_request.location
-            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Fmock_login_requested_return_app_route"  # noqa: E501
         )
 
     def test_login_required_with_return_app_sets_user_attributes_with_valid_token(
@@ -264,5 +264,5 @@ class TestAuthentication:
         assert mock_request.status_code == 200
         assert (
             mock_request.json["logout_url"]
-            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend"
+            == "https://authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Fmock_login_requested_return_app_route"  # noqa: E501
         )


### PR DESCRIPTION

### Change description
adds `request_path` to sign-out url.

This is used by authenticator to redirect to a custom path within the targeted `return_app`


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
If using this version of utils, `request_path` query param should be appended to signed out route if `return_app` is in query params.


### Screenshots of UI changes (if applicable)
