### PR TITLE
Make `toggles` an optional extra

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ _Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if ther
 _A brief description of the pull request_
 
 - [ ] Unit tests and other appropriate tests added or updated
-- [ ] README and other documentation has been updated / added (if needed)
+- [ ] README.md, CHANGELOG.md and other documentation has been updated / added (if needed)
 - [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 5.0.0 (breaking change)
+
+- `fsd_utils.toggles` has been made an optional extra, so its dependencies are not installed automatically. If your
+  uses the `toggles` module, then you should change your `requirements.txt` from `funding-service-design-utils` to
+  `funding-service-design-utils[toggles]`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "4.0.3"
+version = "5.0.0"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
@@ -33,12 +33,16 @@ dependencies = [
     "PyJWT[crypto]>=2.4.0",
     "sentry-sdk[flask]>=2.0.0,<3.0.0",
     "requests==2.32.3",
-    "flipper-client>=1.3.2",
     "flask-redis==0.4.0",
     "Flask-Migrate==4.0.7",
     "Flask-SQLAlchemy>=3.0.3",
     "sqlalchemy-utils>=0.38.3",
     "beautifulsoup4==4.12.3"
+]
+
+[project.optional-dependencies]
+toggles = [
+    "flipper-client>=1.3.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Change description
This means that `flipper-client` will only be installed if the `toggles` extra is requested by the service pulling in fsd-utils.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")