### PR TITLE
Check auth token before falling back to debug user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.0.1
+
+- `login_required` now always checks for a valid session cookie before falling back to a DEBUG_USER in development environments.
+
 # 5.0.0 (breaking change)
 
 - `fsd_utils.toggles` has been made an optional extra, so its dependencies are not installed automatically. If your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.0"
+version = "5.0.1"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },


### PR DESCRIPTION
### Change description
Always try to check the access token in the cookie before checking the debug user.

This means that you can still authenticate normally via a cookie, but if that fails, you fall back to the debug user.