### PR TITLE
Turn warnings into errors; acknowledge existing errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.1"
+version = "5.0.2"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 env =
     FLASK_ENV=unit_test
     FLASK_DEBUG=1
+filterwarnings =
+    error
+    ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:sqlalchemy
+    ignore:datetime.datetime.utcnow:DeprecationWarning:botocore


### PR DESCRIPTION
### Change description
We have two warnings on the repo at the moment, both from dependencies (so outside of our control). One is from botocore
(https://github.com/boto/boto3/issues/3889) and the other is from sqlalchemy. Both are Python 3.12 DeprecationWarnings about datetime.datetime.utcnow and datetime.datetime.utcfromtimestamp being scheduled for removal in future python versions.


### Before
```
================================================== 204 passed, 10 warnings in 1.76s ===================================================
```

### After
```
========================================================= 204 passed in 1.71s =========================================================
```