### PR TITLE
BAU including boto3 so config class continues to work for consumers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     "Flask-Migrate==4.0.7",
     "Flask-SQLAlchemy>=3.0.3",
     "sqlalchemy-utils>=0.38.3",
-    "beautifulsoup4==4.12.3"
+    "beautifulsoup4==4.12.3",
+    "boto3==1.34.144"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.4"
+version = "5.0.5"
 
 authors = [
   { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "Flask-SQLAlchemy>=3.0.3",
     "sqlalchemy-utils>=0.38.3",
     "beautifulsoup4==4.12.3",
-    "boto3==1.34.144"
+    "boto3>=1.9.253"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adding boto3 into the dependencies in [pyproject.toml](./pyproject.toml). Since making toggles an optional extra, `boto3` is not longer installed as a transient dependency of `flipper-client`. But it is needed to load the `configclass` which is used without `flipper-client`