### PR TITLE
Un-pin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+### 5.0.6
+
+- Un-pinned various dependencies
+
+### 5.0.5
+
+- add boto3 dependency to fsd-utils; wasn't included correctly before
+
+### 5.0.4
+
+- add some GOV.UK Notify constants for pre-award
+
+### 5.0.3
+
+- remove some upper-bound pins on dependencies
+
+### 5.0.2
+
+- no external changes
+
 ### 5.0.1
 
 - `login_required` now always checks for a valid session cookie before falling back to a DEBUG_USER in development environments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ name = "funding-service-design-utils"
 version = "5.0.5"
 
 authors = [
-  { name="DLUHC", email="FundingServiceDesignTeam@levellingup.gov.uk" },
+  { name="MHCLG", email="FundingService@communities.gov.uk" },
 ]
-description = "Utilities used by the DLUHC Funding Service Design Team"
+description = "Utilities used by the MHCLG Funding Service Team"
 readme = "README.md"
 license = { file="LICENSE" }
 requires-python = ">=3.10,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.5"
+version = "5.0.6"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,12 @@ dependencies = [
     "pytz>=2022.1",
     "PyJWT[crypto]>=2.4.0",
     "sentry-sdk[flask]>=2.0.0",
-    "requests==2.32.3",
-    "flask-redis==0.4.0",
-    "Flask-Migrate==4.0.7",
+    "requests>=2.32.3",
+    "flask-redis>=0.4.0",
+    "Flask-Migrate>=4.0.7",
     "Flask-SQLAlchemy>=3.0.3",
     "sqlalchemy-utils>=0.38.3",
-    "beautifulsoup4==4.12.3",
+    "beautifulsoup4>=4.12.3",
     "boto3>=1.9.253"
 ]
 


### PR DESCRIPTION
### Change description
FSD-utils is a library package meant to be installed in a variety of
other applications.

Those applications may themselves require other/specific versions of
dependencies. This library should be compatible with as many variations
of dependencies as possible so that it can be installed in all of our
apps with minimal risk of compatibility issues.

So we should not be pinning specific versions here, and instead just say
what range of dep versions should be compatible.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README.md, CHANGELOG.md and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")