### PR TITLE
Make config table optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 5.0.9
+### 5.1.0
 
-- Make Table config print optional
+- Make Table config print optional; set FSD_UTILS_ENABLE_CONFIG_TABLE in the
+env to decide
 
 ### 5.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.0.9
+
+- Make Table config print optional
+
 ### 5.0.6
 
 - Un-pinned various dependencies

--- a/fsd_utils/config/configclass.py
+++ b/fsd_utils/config/configclass.py
@@ -1,3 +1,6 @@
+import os
+
+
 def configclass(cls):
 
     # Checks base classes for _config_info_, a dict containing
@@ -27,6 +30,8 @@ def configclass(cls):
 
     @classmethod
     def pretty_print(self):
+        if os.environ.get("ENABLE_CONFIG_TABLE") == "false":
+            return
 
         from rich.table import Table
         from rich.console import Console

--- a/fsd_utils/config/configclass.py
+++ b/fsd_utils/config/configclass.py
@@ -30,7 +30,7 @@ def configclass(cls):
 
     @classmethod
     def pretty_print(self):
-        if os.environ.get("ENABLE_CONFIG_TABLE") == "false":
+        if os.environ.get("FSD_UTILS_ENABLE_CONFIG_TABLE") == "false":
             return
 
         from rich.table import Table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.9"
+version = "5.1.0"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.0.8"
+version = "5.0.9"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },


### PR DESCRIPTION
### Change description
Allow for the Table config print to be optional.

Default behaviour prints the table, as before.
Set `FSD_UTILS_ENABLE_CONFIG_TABLE` to "false". To turn it off.

### How to test
Not very easy..

- Set `FSD_UTILS_ENABLE_CONFIG_TABLE=false` in the docker runner
- Install this branch version of utils by updating the requirements.txt with
```
funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils@327697124975ac550874448512c1b4a88501b31f
```
- The service that uses this version of utils will not print a table

Or... 

Take my word for it. :+1: 
