### PR TITLE
Fix code scanning alert - Failure to use secure cookies

### DIFF
--- a/fsd_utils/locale_selector/set_lang.py
+++ b/fsd_utils/locale_selector/set_lang.py
@@ -23,6 +23,9 @@ class LanguageSelector:
                 current_app.config["COOKIE_DOMAIN"]
             ),
             max_age=86400 * 30,  # 30 days
+            secure=True,
+            samesite="Lax",
+            httponly=True,
         )
 
     def __init__(self, app):

--- a/tests/test_set_lang.py
+++ b/tests/test_set_lang.py
@@ -13,9 +13,15 @@ def test_set_lang(flask_test_client):
         response_cookie = response.headers.get("Set-Cookie")
         assert response_cookie is not None, "No cookie set for language"
         assert response_cookie.split(";")[0] == ("language" + "=cy")
-        assert "Secure" in response_cookie, "Secure attribute not set for language cookie"
-        assert "SameSite=Lax" in response_cookie, "SameSite attribute not set to Lax for language cookie"
-        assert "HttpOnly" in response_cookie, "HttpOnly attribute not set for language cookie"
+        assert (
+            "Secure" in response_cookie
+        ), "Secure attribute not set for language cookie"
+        assert (
+            "SameSite=Lax" in response_cookie
+        ), "SameSite attribute not set to Lax for language cookie"
+        assert (
+            "HttpOnly" in response_cookie
+        ), "HttpOnly attribute not set for language cookie"
 
 
 def test_set_language_cookie_attributes(flask_test_client):
@@ -26,6 +32,12 @@ def test_set_language_cookie_attributes(flask_test_client):
         set_lang.set_language_cookie("cy", response)
         response_cookie = response.headers.get("Set-Cookie")
         assert response_cookie is not None, "No cookie set for language"
-        assert "Secure" in response_cookie, "Secure attribute not set for language cookie"
-        assert "SameSite=Lax" in response_cookie, "SameSite attribute not set to Lax for language cookie"
-        assert "HttpOnly" in response_cookie, "HttpOnly attribute not set for language cookie"
+        assert (
+            "Secure" in response_cookie
+        ), "Secure attribute not set for language cookie"
+        assert (
+            "SameSite=Lax" in response_cookie
+        ), "SameSite attribute not set to Lax for language cookie"
+        assert (
+            "HttpOnly" in response_cookie
+        ), "HttpOnly attribute not set for language cookie"

--- a/tests/test_set_lang.py
+++ b/tests/test_set_lang.py
@@ -13,3 +13,19 @@ def test_set_lang(flask_test_client):
         response_cookie = response.headers.get("Set-Cookie")
         assert response_cookie is not None, "No cookie set for language"
         assert response_cookie.split(";")[0] == ("language" + "=cy")
+        assert "Secure" in response_cookie, "Secure attribute not set for language cookie"
+        assert "SameSite=Lax" in response_cookie, "SameSite attribute not set to Lax for language cookie"
+        assert "HttpOnly" in response_cookie, "HttpOnly attribute not set for language cookie"
+
+
+def test_set_language_cookie_attributes(flask_test_client):
+    mock_app = Mock()
+    set_lang = LanguageSelector(mock_app)
+    with flask_test_client.application.test_request_context():
+        response = flask_test_client.response_class()
+        set_lang.set_language_cookie("cy", response)
+        response_cookie = response.headers.get("Set-Cookie")
+        assert response_cookie is not None, "No cookie set for language"
+        assert "Secure" in response_cookie, "Secure attribute not set for language cookie"
+        assert "SameSite=Lax" in response_cookie, "SameSite attribute not set to Lax for language cookie"
+        assert "HttpOnly" in response_cookie, "HttpOnly attribute not set for language cookie"


### PR DESCRIPTION
Fixes #174

Fix the code scanning alert for failure to use secure cookies.

* Set the `secure` attribute to `True` in the `set_language_cookie` method in `fsd_utils/locale_selector/set_lang.py`.
* Set the `samesite` attribute to `Lax` in the `set_language_cookie` method in `fsd_utils/locale_selector/set_lang.py`.
* Set the `httponly` attribute to `True` in the `set_language_cookie` method in `fsd_utils/locale_selector/set_lang.py`.
* Add tests in `tests/test_set_lang.py` to check if the `secure`, `samesite`, and `httponly` attributes are set correctly in the `set_language_cookie` and `select_language` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/communitiesuk/funding-service-design-utils/issues/174?shareId=9ec0788c-e881-4e1f-bd70-242386f81bbc).