### PR TITLE
Revert "Set cookie attributes for "security""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 5.1.4
+* Revert 5.3.1, as forcing secure=true is broken for local development in some cases (where HTTPS is not used). To be fixed properly by another future patch.
+
+### 5.1.3
+
+* Make the `lang` cookie secure/httponly/samesite=lax.
+
 ### 5.1.2
 
 - Return default language as "en" if "language" cookie is not " en/cy "

--- a/fsd_utils/locale_selector/set_lang.py
+++ b/fsd_utils/locale_selector/set_lang.py
@@ -23,9 +23,6 @@ class LanguageSelector:
                 current_app.config["COOKIE_DOMAIN"]
             ),
             max_age=86400 * 30,  # 30 days
-            httponly=True,
-            secure=True,
-            samesite="Lax",
         )
 
     def __init__(self, app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.3"
+version = "5.1.4"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/tests/test_set_lang.py
+++ b/tests/test_set_lang.py
@@ -13,6 +13,3 @@ def test_set_lang(flask_test_client):
         response_cookie = response.headers.get("Set-Cookie")
         assert response_cookie is not None, "No cookie set for language"
         assert response_cookie.split(";")[0] == ("language" + "=cy")
-        assert "Secure" in response_cookie
-        assert "HttpOnly" in response_cookie
-        assert "SameSite=Lax" in response_cookie


### PR DESCRIPTION
### Change description
This reverts commit 8e7e0500b320c76e58ea1f4a6a583d73b15e05aa.

The apps themselves control these attributes through SESSION_COOKIE_* config options, so it's a bit inconsistent to override this.

It also means that the cookie may not be passed through for insecure HTTP on local development, which is still used by pre-award.