### PR TITLE
Upgrade pre-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.1.5
+
+* No functional changes (bumping local pre-commit).
+
 ### 5.1.4
 * Revert 5.3.1, as forcing secure=true is broken for local development in some cases (where HTTPS is not used). To be fixed properly by another future patch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.4"
+version = "5.1.5"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 
-pre-commit
+pre-commit~=4.0.0
 pytest-env>=0.6.2
 pytest
 pytest-mock


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.