### PR TITLE
Override the central rangeStrategy=pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.7"
+version = "5.1.8"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>communitiesuk/renovate-config"
-  ]
+  ],
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
### Change description
For libraries, we generally want to support ranges of versions rather than just specific versions of things (the latter makes more sense for applications). Our [central config](https://github.com/communitiesuk/renovate-config) is specced for applications

This change will make renovate support ranges in pyproject.toml, and replace the range only when a new version of a dependency falls outside of that range.

Eg if we pinned `Flask~=2.0`, then when Flask 3.0.0 is released it would bump it to `Flask~=3.0`.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README.md, CHANGELOG.md and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
