### PR TITLE
FS-4805 - Adding FAB to the SupportedApp enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.1.9
+
+* Adding FAB to the list of supported apps
+
+### 5.1.8
+
+* No functional changes (overriding the central rangeStrategy=pin)
+
 ### 5.1.7
 
 * No functional changes (fix packaging with uv).

--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -20,3 +20,4 @@ user_route = "/service/user"
 class SupportedApp(enum.Enum):
     POST_AWARD_FRONTEND = "post-award-frontend"
     POST_AWARD_SUBMIT = "post-award-submit"
+    FUND_APPLICATION_BUILDER = "fund-application-builder"


### PR DESCRIPTION
### Ticket

[Add authentication for FAB](https://mhclgdigital.atlassian.net/browse/FS-4805)

### Description

See ticket for wider context. This PR specifically is to add FAB to the `SupportedApp` enum alongside the other frontend apps that use authentication - Submit and Find (Assess is handled in a bespoke way).