### PR TITLE
FS-4805 - FAB authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### 5.2.0
+
+* Adding check internal user functionality and adding FAB and Form Designer to list of supported apps
+
+### 5.1.10
+
+* Running `uv lock` when version incremented
+
+### 5.1.9
+
+* Changing to a negative check for the environment list
+
+### 5.1.8
+
+* Overriding the central rangeStrategy=pin
+
 ### 5.1.7
 
 * No functional changes (fix packaging with uv).

--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -20,3 +20,10 @@ user_route = "/service/user"
 class SupportedApp(enum.Enum):
     POST_AWARD_FRONTEND = "post-award-frontend"
     POST_AWARD_SUBMIT = "post-award-submit"
+    FORM_DESIGNER = "form-designer"
+    FUND_APPLICATION_BUILDER = "fund-application-builder"
+
+
+class InternalDomain(str, enum.Enum):
+    COMMUNITIES = "@communities.gov.uk"
+    TEST_COMMUNITIES = "@test.communities.gov.uk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.10"
+version = "5.2.0"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,7 @@ def flask_test_check_internal_user_client():
             "/mock_check_internal_user_route",
             "mock_check_internal_user_route",
             mock_check_internal_user_route,
-            methods=["GET"]
+            methods=["GET"],
         )
 
         with app_context.app.test_client() as test_client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from flask import Flask, g
 
 from fsd_utils.authentication.config import SupportedApp
-from fsd_utils.authentication.decorators import login_requested, login_required
+from fsd_utils.authentication.decorators import check_internal_user, login_requested, login_required
 
 
 def create_app():
@@ -118,6 +118,37 @@ def flask_test_development_client():
             "mock_login_required_admin_roles_route",
             mock_login_required_admin_roles_route,
         )
+        with app_context.app.test_client() as test_client:
+            yield test_client
+
+
+@pytest.fixture(scope="function")
+def flask_test_check_internal_user_client():
+    """
+    Creates the test client for check_internal_user tests.
+    """
+    with create_app().app_context() as app_context:
+        _test_public_key_path = str(Path(__file__).parent) + "/keys/rsa256/public.pem"
+        with open(_test_public_key_path, mode="rb") as public_key_file:
+            rsa256_public_key = public_key_file.read()
+
+        app_context.app.config.update(
+            {
+                "FSD_LANG_COOKIE_NAME": "language",
+                "COOKIE_DOMAIN": None,
+                "FSD_USER_TOKEN_COOKIE_NAME": "fsd-user-token",
+                "AUTHENTICATOR_HOST": "https://authenticator",
+                "RSA256_PUBLIC_KEY": rsa256_public_key,
+            }
+        )
+
+        app_context.app.add_url_rule(
+            "/mock_check_internal_user_route",
+            "mock_check_internal_user_route",
+            mock_check_internal_user_route,
+            methods=["GET"]
+        )
+
         with app_context.app.test_client() as test_client:
             yield test_client
 
@@ -251,6 +282,12 @@ def mock_login_requested_return_app_route():
     :return: the Flask g variable serialised as a dict/json
     """
     return vars(g)
+
+
+@login_requested
+@check_internal_user
+def mock_check_internal_user_route():
+    return {"status": "ok"}
 
 
 @pytest.fixture(scope="function")

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.1.10"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### Tickets

- [Add authentication to FAB](https://mhclgdigital.atlassian.net/browse/FS-4805)
- [Share check internal user functionality across apps](https://mhclgdigital.atlassian.net/browse/FS-4871)
- [Form Designer authentication](https://mhclgdigital.atlassian.net/browse/FS-4794)

### Description

**Add authentication to FAB**

FAB needs to be added to the `SupportedApp` enum in order to be authenticated.


**Share check internal user functionality across apps** (sub-task of "Add authentication to FAB")

This functionality already exists in Post-Award Data Store, here: https://github.com/communitiesuk/funding-service-design-post-award-data-store/blob/main/find/main/decorators.py

Now this functionality is required by FAB, so we need to move that functionality to a shared location i.e., utils library.

Once this PR is merged, Post-Award's Data Store can point to the updated fsd-utils and remove its own implementation of this functionality.


**Form Designer authentication** (not strictly related add-on to save a separate PR)

I have also added Form Designer to the `SupportedApp` enum pre-emptively, to free up further work on this ticket.
