### PR TITLE
Changing to a negative check for the environment list

### DIFF
--- a/fsd_utils/config/commonconfig.py
+++ b/fsd_utils/config/commonconfig.py
@@ -6,7 +6,7 @@ class CommonConfig:
     def _resolve_secret_key(flask_env: str = None) -> str:
         secret_key = os.getenv("SECRET_KEY", None)
         if not secret_key:
-            if flask_env in ["dev", "test", "uat", "production"]:
+            if flask_env not in ["unit_test", "development"]:
                 raise KeyError("SECRET_KEY is not present in environment")
             secret_key = "dev-secret"  # pragma: allowlist secret
         return secret_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.8"
+version = "5.1.9"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,8 @@ from fsd_utils.config.commonconfig import CommonConfig
         ("development", "dev_key", "dev_key"),
         ("uat", "abc123", "abc123"),
         ("development", "", "dev-secret"),
-        ("db_migrations", "", "dev-secret"),
+        ("unit_test", "", "dev-secret"),
+        ("prod", "prod_secret", "prod_secret"),
     ],
 )
 def test_config(flask_env, env_secret_key, exp_secret_key):
@@ -41,6 +42,8 @@ def test_config(flask_env, env_secret_key, exp_secret_key):
             "production",
             "",
         ),
+        ("db_migrations", ""),
+        ("prod", ""),
     ],
 )
 def test_config_error(flask_env, env_secret_key):

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.1.8"
+version = "5.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.1.6"
+version = "5.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### Change description
Updating the check in `CommonConfig` for the `SECRET_KEY` to use a `not in` check for whether to raise an error. This should fix an issue where the post award services were throwing an error on production because there is a difference in environment naming between pre and post award (`prod` vs `production`)

- [x] Unit tests and other appropriate tests added or updated
- [ ] README.md, CHANGELOG.md and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

