### PR TITLE
Running uv lock when version incremented

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -35,6 +35,9 @@ jobs:
         current-version: ${{ steps.latest_tag.outputs.tag}}
         version-fragment: 'bug'
 
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@e779db74266a80753577425b0f4ee823649f251d # v3
+
     - name: Update version in pyproject.toml
       id: update_version
       run: |

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -40,9 +40,11 @@ jobs:
       run: |
         echo Updating version from ${{ steps.package_version.outputs.app_version}} to ${{ steps.bump_version.outputs.next-version }}
         sed -i 's/version = "${{ steps.package_version.outputs.app_version}}"/version = "${{ steps.bump_version.outputs.next-version }}"/' pyproject.toml
+        uv lock
         git config user.name 'FSD Github Actions'
         git config user.email "fsd@levellingup.gov.uk"
         git add pyproject.toml
+        git add uv.lock
         git commit -m "Update version to ${{ steps.bump_version.outputs.next-version }}"
         git push origin $GITHUB_HEAD_REF
         echo "Updated pyproject.toml with version ${{ steps.bump_version.outputs.next-version }}" >> $GITHUB_STEP_SUMMARY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "5.1.9"
+version = "5.1.10"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.1.9"
+version = "5.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### Change description
Now we use `uv` to manage dependencies, the version in `pyproject.toml` is used to reference the utils package. This PR adds a `uv lock` call to the version increment job to that `uv.lock` is kept in sync with `pyproject.toml`
