### PR TITLE
Add platform as supported app temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.2
+
+* Add funding-service as a supported return app for authenticator.
+
 ### 6.1.0
 
 * Add `source_app` parameter to `_failed_roles_redirect`

--- a/fsd_utils/authentication/config.py
+++ b/fsd_utils/authentication/config.py
@@ -22,6 +22,7 @@ class SupportedApp(enum.Enum):
     POST_AWARD_SUBMIT = "post-award-submit"
     FORM_DESIGNER = "form-designer"
     FUND_APPLICATION_BUILDER = "fund-application-builder"
+    FUNDING_SERVICE = "funding-service"
 
 
 class InternalDomain(str, enum.Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "funding-service-design-utils"
 
-version = "6.1.1"
+version = "6.1.2"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.10, <4.0"
 
 [[package]]
@@ -241,7 +240,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -407,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "6.1.1"
+version = "6.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -465,7 +464,6 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["flask"], specifier = ">=2.0.0" },
     { name = "sqlalchemy-utils", specifier = ">=0.38.3" },
 ]
-provides-extras = ["toggles"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
We want to add the ability to login via SSO to the platform, but we don't currently have proper domains which will make integrating with Microsoft AD infeasible.

As a temporary step, we're going to proxy auth via the existing authenticator service. Once we've got our domains set up, we'll tear down this logic and build an SSO flow as part of the funding-service repo directly.

In order to support proxying auth via authenticator, we'll set up the new funding-service as a safe return app.

We expect this proxying behaviour to last 1-2 weeks.

https://mhclgdigital.atlassian.net/browse/FSPT-393