### PR TITLE
Start to retire the UAT environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "funding-service-design-utils"
-
-version = "6.1.3"
+version = "6.1.4"
 
 authors = [
   { name="MHCLG", email="FundingService@communities.gov.uk" },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,6 @@ from fsd_utils.config.commonconfig import CommonConfig
     [
         ("dev", "dev_key", "dev_key"),
         ("development", "dev_key", "dev_key"),
-        ("uat", "abc123", "abc123"),
         ("development", "", "dev-secret"),
         ("unit_test", "", "dev-secret"),
         ("prod", "prod_secret", "prod_secret"),
@@ -32,10 +31,6 @@ def test_config(flask_env, env_secret_key, exp_secret_key):
         ),
         (
             "test",
-            "",
-        ),
-        (
-            "uat",
             "",
         ),
         (

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "6.1.3"
+version = "6.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-342

https://github.com/communitiesuk/funding-service-requests-for-comments/discussions/17

As per the conclusion of the above RFC, we're moving away from having three pipelined environments to two (test/prod) and a free-for-all pre-merge env (dev).

This patch removes all concepts of the UAT env from the app, but won't tear down the app instances themselves yet. We'll do this manually later when all of our services have been updated and the UAT env is disconnected from all pipelines/etc.