### PR TITLE
Fix MultiInput Mapping Error for repeating inputs

### DIFF
--- a/fsd_utils/mapping/application/multi_input_utils.py
+++ b/fsd_utils/mapping/application/multi_input_utils.py
@@ -155,7 +155,11 @@ class ProcessTypes:
                             _str_key[0],
                         )
 
-        _values = [val for val in item.values() if val != key if not isinstance(val, dict)]
+        # make a mutable list of values, remove only one occurrence of key, then filter out dicts
+        vals = list(item.values())
+        if key in vals:
+            vals.remove(key)
+        _values = [v for v in vals if not isinstance(v, dict)]
         combined_values.extend(_values)
 
         if combined_values and key:

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -279,7 +279,7 @@ test_data_sort_questions_answers = {
             "Which membership organisations are you a member of?": "Homeless link",
             "When did you start providing day provision?": "March 2023",
             "Revenue costs": "Test Funding Required NS Form \n      . 40\n      . 1 April 2023 to 31 March 2024\n      . Not provided",  # noqa
-            "Capital costs": "Test Funding Required NS Form \n      . 50\n      . 1 April 2024 to 31 March 2025",
+            "Capital costs": "Test Funding Required NS Form \n      . 50\n      . 1 April 2024 to 31 March 2025\n      . Test Funding Required NS Form",  # noqa
             "Does your organisation have any alternative names?": "Yes",
         }
     },


### PR DESCRIPTION
Fixes an issue where submitting a form with MultiInput Field having identical values across all input fields [caused an error](https://funding-service-design-team-dl.sentry.io/issues/6677776751/?alert_rule_id=15583723&alert_type=issue&notification_uuid=cb97fa94-1329-4852-9984-e5f081e63e7d&project=4508324370317312&referrer=slack) during Q&A generation. The root cause was that all values were being skipped due to the removal of all instances of a repeated value.

### Change description
- Updated logic to convert dictionary values to a list and remove **only the first occurrence** of the specified key value.
- Ensures that repeated values are preserved, preventing unintended data loss.

- [X] Unit tests and other appropriate tests added or updated
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")